### PR TITLE
Work for issue #9

### DIFF
--- a/lib/deride.js
+++ b/lib/deride.js
@@ -56,8 +56,8 @@ var Expectations = function() {
         assert.equal(timesCalled, number, err);
     }
 
-    function never() {
-        assert.equal(timesCalled, 0);
+    function never(err) {
+        assert.equal(timesCalled, 0, err);
     }
 
     function calledOnce(err) {

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -179,6 +179,15 @@ _.forEach(tests, function(test) {
             done();
         });
 
+        it('can return a bespoke error for called NEVER', function(done) {
+            bob = deride.wrap(bob);
+            bob.greet('alice');
+            assert.throws(function() {
+                bob.expect.greet.called.never('This is a bespoke error');
+            }, /This is a bespoke error/);
+            done();
+        });
+
         it('enables the determination of the args used to invoke the method', function(done) {
             bob = deride.wrap(bob);
             bob.greet('alice');
@@ -186,7 +195,7 @@ _.forEach(tests, function(test) {
             bob.expect.greet.called.withArgs('bob');
             done();
         });
-
+        
         it('enables overriding a methods body', function(done) {
             bob = deride.wrap(bob);
             bob.setup.greet.toDoThis(function(otherPersonName) {


### PR DESCRIPTION
Enabled bespoke errors on .never .twice. once and .times
https://github.com/REAANDREW/deride/issues/9 
