### PR TITLE
Wrapped classes now maintain their non-method properties

### DIFF
--- a/lib/deride.js
+++ b/lib/deride.js
@@ -232,7 +232,7 @@ function wrap(obj) {
 
     self.expect = expectMethods;
     self.setup = setupMethods;
-    return Object.freeze(self);
+    return Object.freeze(_.merge({}, obj, self));
 }
 
 function func() {

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -135,6 +135,17 @@ describe('Single function', function() {
       done();
     });
 
+    it('Wrapping a class does not remove non-functions', function() {
+      var MyClass = function() {
+        return {
+          aValue: 1,
+          doStuff: function() {}
+        };
+      };
+      var myClass = deride.wrap(new MyClass());
+      myClass.should.have.property('aValue');
+    });
+
     it('can setup a return value', function(done) {
         var func = deride.func();
         func.setup.toReturn(1);


### PR DESCRIPTION
At the moment an object with non method properties will lose those properties if you wrap it.
eg:
{ 
  value: 1,
  method: function() 
}

would become:
{ 
  method: function() 
}

after a .wrap.

This pull request fixes that.
