### PR TITLE
Exact matcher with tests - thoughts?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .npmrc
 .idea
+*.iml
 
 reports/
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .npmrc
+.idea
 
 reports/
 *.swp

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ bob.expect.greet.called.withArgs('bob');
 
 <a name="called-matchexactly" />
 
-### Determine if a method was called with the Exact set of arguments
+### Determine if a method was called with the exact set of arguments
 ```javascript
 var bob = new Person('bob');
 bob = deride.wrap(bob);

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var deride = require('deride');
 - [```obj```.expect.```method```.called.withArg(arg)](#called-witharg)
 - [```obj```.expect.```method```.called.withArgs(args)](#called-withargs)
 - [```obj```.expect.```method```.called.withMatch(pattern)](#called-withmatch)
+- [```obj```.expect.```method```.called.matchExactly(args)](#called-matchexactly)
 
 **All of the above can be negated e.g. negating the `.withArgs` would be: ** 
 
@@ -246,6 +247,16 @@ bob = deride.wrap(bob);
 bob.greet('alice');
 bob.greet('bob');
 bob.expect.greet.called.withArgs('bob');
+```
+
+<a name="called-matchexactly" />
+
+### Determine if a method was called with the Exact set of arguments
+```javascript
+var bob = new Person('bob');
+bob = deride.wrap(bob);
+bob.greet('alice', ['james'], 987);
+bob.expect.greet.called.matchExactly('alice', ['james'], 987);
 ```
 
 <a name="setup-todothis" />

--- a/lib/deride.js
+++ b/lib/deride.js
@@ -100,7 +100,7 @@ function Expectations(obj, method) {
         }
     }
     
-    function exact() {
+    function matchExactly() {
         var expectedArgs = _.values(arguments);
         var matched = true;
         _.forEach(calledWithArgs, function (args) {
@@ -114,7 +114,7 @@ function Expectations(obj, method) {
             });
         });
         if (!matched) {
-            assert.fail(calledWithArgs, expectedArgs, 'Expected ' + method + ' to be called exact args' + require('util').inspect(expectedArgs, {depth: 10}));
+            assert.fail(calledWithArgs, expectedArgs, 'Expected ' + method + ' to be called matchExactly args' + require('util').inspect(expectedArgs, {depth: 10}));
         }
     }
     
@@ -240,7 +240,7 @@ function Expectations(obj, method) {
             gt: calledGt,
             gte: calledGte,
             reset: reset,
-            exact: exact,
+            matchExactly: matchExactly,
             withArgs: withArgs,
             withArg: withSingleArg,
             withMatch: withMatch

--- a/lib/deride.js
+++ b/lib/deride.js
@@ -99,7 +99,25 @@ function Expectations(obj, method) {
             assert.fail(calledWithArgs, pattern, 'Expected ' + method + ' to be called matching: ' + pattern);
         }
     }
-
+    
+    function exact() {
+        var expectedArgs = _.values(arguments);
+        var matched = true;
+        _.forEach(calledWithArgs, function (args) {
+            _.forEach(_.values(args), function (arg, i) {
+                if (!_.isEqual(arg, expectedArgs[i])) {
+                    matched = false;
+                    debug('is object match?', matched, arg, expectedArgs[i]);
+                    return;
+                }
+                debug('is match?', matched, arg, expectedArgs[i]);
+            });
+        });
+        if (!matched) {
+            assert.fail(calledWithArgs, expectedArgs, 'Expected ' + method + ' to be called exact args' + require('util').inspect(expectedArgs, {depth: 10}));
+        }
+    }
+    
     function objectPatternMatchProperties(obj, pattern) {
         var matched = false;
         _.deepMapValues(obj, function(i) {
@@ -222,6 +240,7 @@ function Expectations(obj, method) {
             gt: calledGt,
             gte: calledGte,
             reset: reset,
+            exact: exact,
             withArgs: withArgs,
             withArg: withSingleArg,
             withMatch: withMatch

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -367,25 +367,25 @@ describe('Exact', function () {
         done();
     });
 
-    it('with a simply primative string', function (done) {
+    it('with a primative string', function (done) {
         bob.greet('bob');
         bob.expect.greet.called.exact('bob');
         done();
     });
 
-    it('with multiple a simply primative string', function (done) {
+    it('with multiple a primative strings', function (done) {
         bob.greet('alice', 'carol');
         bob.expect.greet.called.exact('alice', 'carol');
         done();
     });
 
-    it('with mixed string and primatives', function (done) {
+    it('with mixed strings, arrays and numbers', function (done) {
         bob.greet('alice', ['carol'], 123);
         bob.expect.greet.called.exact('alice', ['carol'], 123);
         done();
     });
 
-    it('with mixture of primative and object args', function () {
+    it('with mixture of primatives and objects', function () {
         bob.greet('alice', ['carol'], 123, {
             name: 'bob',
             a: 1
@@ -405,6 +405,26 @@ describe('Exact', function () {
             name: 'bob',
             a: 1
         }), 'sam');
+    });
+    
+    it('with a new instance', function () {
+        var Obj = function() {
+            return {
+                times: function (arg) {
+                    return arg;
+                }
+            };
+        };
+        bob.greet(new Obj());
+        bob.expect.greet.called.exact(new Obj());
+    });
+    
+    it('with a function', function () {
+        var func = function() {
+            return 12345;
+        };
+        bob.greet(func);
+        bob.expect.greet.called.exact(func);
     });
 });
 

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -360,6 +360,54 @@ describe('Properties', function() {
     });
 });
 
+describe('Exact', function () {
+    var bob;
+    beforeEach(function (done) {
+        bob = deride.stub(['greet']);
+        done();
+    });
+
+    it('with a simply primative string', function (done) {
+        bob.greet('bob');
+        bob.expect.greet.called.exact('bob');
+        done();
+    });
+
+    it('with multiple a simply primative string', function (done) {
+        bob.greet('alice', 'carol');
+        bob.expect.greet.called.exact('alice', 'carol');
+        done();
+    });
+
+    it('with mixed string and primatives', function (done) {
+        bob.greet('alice', ['carol'], 123);
+        bob.expect.greet.called.exact('alice', ['carol'], 123);
+        done();
+    });
+
+    it('with mixture of primative and object args', function () {
+        bob.greet('alice', ['carol'], 123, {
+            name: 'bob',
+            a: 1
+        }, 'sam');
+        bob.expect.greet.called.exact('alice', ['carol'], 123, {
+            name: 'bob',
+            a: 1
+        }, 'sam');
+    });
+
+    it('with a frozen object', function () {
+        bob.greet(Object.freeze({
+            name: 'bob',
+            a: 1
+        }), 'sam');
+        bob.expect.greet.called.exact(Object.freeze({
+            name: 'bob',
+            a: 1
+        }), 'sam');
+    });
+});
+
 var fooBarFunction = function(timeout, callback) {
     setTimeout(function() {
         callback('result');

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -200,6 +200,29 @@ describe('Expectations', function() {
 
         bob.expect.greet.called.withMatch(/^talula/gi);
     });
+
+    describe('matchExactly causes failures', function () {
+
+        it('with mixed strings, arrays and numbers', function () {
+            bob.greet('alice', ['carol'], 123);
+            (function () {
+                bob.expect.greet.called.matchExactly('not-alice', ['or-carol'], 987);
+            }).should.throw('Expected greet to be called matchExactly args[ \'not-alice\', [ \'or-carol\' ], 987 ]');
+        });
+
+        it('with mixture of primitives and objects', function () {
+            bob.greet('alice', ['carol'], 123, {
+                name: 'bob',
+                a: 1
+            }, 'sam');
+            (function () {
+                bob.expect.greet.called.matchExactly('alice', ['carol'], 123, {
+                    name: 'not-bob',
+                    a: 1
+                }, 'not-sam');
+            }).should.throw('Expected greet to be called matchExactly args[ \'alice\', [ \'carol\' ], 123, { name: \'not-bob\', a: 1 }, \'not-sam\' ]');
+        });
+    });
 });
 
 describe('Single function', function() {
@@ -360,74 +383,6 @@ describe('Properties', function() {
     });
 });
 
-describe('Exact', function () {
-    var bob;
-    beforeEach(function (done) {
-        bob = deride.stub(['greet']);
-        done();
-    });
-
-    it('with a primative string', function (done) {
-        bob.greet('bob');
-        bob.expect.greet.called.exact('bob');
-        done();
-    });
-
-    it('with multiple a primative strings', function (done) {
-        bob.greet('alice', 'carol');
-        bob.expect.greet.called.exact('alice', 'carol');
-        done();
-    });
-
-    it('with mixed strings, arrays and numbers', function (done) {
-        bob.greet('alice', ['carol'], 123);
-        bob.expect.greet.called.exact('alice', ['carol'], 123);
-        done();
-    });
-
-    it('with mixture of primatives and objects', function () {
-        bob.greet('alice', ['carol'], 123, {
-            name: 'bob',
-            a: 1
-        }, 'sam');
-        bob.expect.greet.called.exact('alice', ['carol'], 123, {
-            name: 'bob',
-            a: 1
-        }, 'sam');
-    });
-
-    it('with a frozen object', function () {
-        bob.greet(Object.freeze({
-            name: 'bob',
-            a: 1
-        }), 'sam');
-        bob.expect.greet.called.exact(Object.freeze({
-            name: 'bob',
-            a: 1
-        }), 'sam');
-    });
-    
-    it('with a new instance', function () {
-        var Obj = function() {
-            return {
-                times: function (arg) {
-                    return arg;
-                }
-            };
-        };
-        bob.greet(new Obj());
-        bob.expect.greet.called.exact(new Obj());
-    });
-    
-    it('with a function', function () {
-        var func = function() {
-            return 12345;
-        };
-        bob.greet(func);
-        bob.expect.greet.called.exact(func);
-    });
-});
-
 var fooBarFunction = function(timeout, callback) {
     setTimeout(function() {
         callback('result');
@@ -548,6 +503,74 @@ _.forEach(tests, function(test) {
         });
     });
 
+    describe(test.name + ':matchExactly', function () {
+        beforeEach(function(done) {
+            bob = test.setup();
+            done();
+        });
+
+        it('with a primitive string', function (done) {
+            bob.greet('bob');
+            bob.expect.greet.called.matchExactly('bob');
+            done();
+        });
+
+        it('with multiple a primitive strings', function (done) {
+            bob.greet('alice', 'carol');
+            bob.expect.greet.called.matchExactly('alice', 'carol');
+            done();
+        });
+
+        it('with mixed strings, arrays and numbers', function (done) {
+            bob.greet('alice', ['carol'], 123);
+            bob.expect.greet.called.matchExactly('alice', ['carol'], 123);
+            done();
+        });
+
+        it('with mixture of primitives and objects', function () {
+            bob.greet('alice', ['carol'], 123, {
+                name: 'bob',
+                a: 1
+            }, 'sam');
+            bob.expect.greet.called.matchExactly('alice', ['carol'], 123, {
+                name: 'bob',
+                a: 1
+            }, 'sam');
+        });
+
+        it('with a frozen object', function () {
+            bob.greet(Object.freeze({
+                name: 'bob',
+                a: 1
+            }), 'sam');
+            bob.expect.greet.called.matchExactly(Object.freeze({
+                name: 'bob',
+                a: 1
+            }), 'sam');
+        });
+
+        it('with same instance', function () {
+            var Obj = function() {
+                return {
+                    times: function (arg) {
+                        return arg;
+                    }
+                };
+            };
+            var o = new Obj();
+            bob.greet(o);
+            bob.expect.greet.called.matchExactly(o);
+        });
+
+        it('with a function', function () {
+            var func = function() {
+                return 12345;
+            };
+            bob.greet(func);
+            bob.expect.greet.called.matchExactly(func);
+        });
+    });
+    
     describe(test.name + ':invocation', function() {
         beforeEach(function(done) {
             bob = test.setup();


### PR DESCRIPTION
Recently I had problems with `withArgs()` as it does not do full equality checking on the args provided and hence have added a new `matchExactly()` expectation. 

This simply checks that all the args provided are exactly the same and in the same order of the expected invocation. 

Does this make sense, maybe there is a better or existing way, feedback welcome.
 
James