### PR TITLE
Allow for multiple predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deride [![Build Status](https://travis-ci.org/guzzlerio/deride.svg?branch=master)](https://travis-ci.org/guzzlerio/deride) [![NPM version](https://badge.fury.io/js/deride.svg)](http://badge.fury.io/js/deride) [![Dependency Status](https://david-dm.org/guzzlerio/deride.svg)](https://david-dm.org/guzzlerio/deride) [![Stories in Ready](https://badge.waffle.io/guzzlerio/deride.png?label=ready&title=Ready)](https://waffle.io/guzzlerio/deride) [![Stories In Progress](https://badge.waffle.io/guzzlerio/deride.png?label=in%20progress&title=In%20Progres)](https://waffle.io/guzzlerio/deride) 
+# deride [![Build Status](https://travis-ci.org/guzzlerio/deride.svg?branch=master)](https://travis-ci.org/guzzlerio/deride) [![NPM version](https://badge.fury.io/js/deride.svg)](http://badge.fury.io/js/deride) [![Dependency Status](https://david-dm.org/guzzlerio/deride.svg)](https://david-dm.org/guzzlerio/deride) [![Stories in Ready](https://badge.waffle.io/guzzlerio/deride.png?label=ready&title=Ready)](https://waffle.io/guzzlerio/deride) [![Stories In Progress](https://badge.waffle.io/guzzlerio/deride.png?label=in%20progress&title=In%20Progres)](https://waffle.io/guzzlerio/deride)
 
 [![NPM](https://nodei.co/npm/deride.png?downloadRank=true&downloads=true)](https://nodei.co/npm/deride/)
 
@@ -41,7 +41,7 @@ var deride = require('deride');
 - [```obj```.expect.```method```.called.withMatch(pattern)](#called-withmatch)
 - [```obj```.expect.```method```.called.matchExactly(args)](#called-matchexactly)
 
-**All of the above can be negated e.g. negating the `.withArgs` would be: ** 
+**All of the above can be negated e.g. negating the `.withArgs` would be:**
 
 - ```obj```.expect.```method```.called`.not`.withArgs(args)
 
@@ -93,7 +93,7 @@ bob.expect.greet.called.times(1);
 <a name="stub-obj" />
 
 ### Creating a stubbed object with properties
-To stub an object with pre set properties call the stub method with a properties array in the second parameter. We are following the defineProperty definition as can be found in the below link. 
+To stub an object with pre set properties call the stub method with a properties array in the second parameter. We are following the defineProperty definition as can be found in the below link.
 
 https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
 
@@ -407,7 +407,7 @@ result2.should.eql('barfoo');
 
 <a name="setup-todothis-when" />
 
-### Overriding a method`s body when specific arguments are provided
+### Overriding a method's body when specific arguments are provided
 ``` javascript
 var bob = new Person('bob');
 bob = deride.wrap(bob);
@@ -508,6 +508,35 @@ var matchingMsg = {
 	}))
 };
 bob.chuckle(matchingMsg).should.eql('chuckle talula');
+```
+
+
+### Setting multiple functions as a predicates
+
+```javascript
+function tatulaMatchingPredicate(msg) {
+	var content = JSON.parse(msg.content.toString());
+	return content.resource === 'talula';
+}
+function babulaMatchingPredicate(msg) {
+	var content = JSON.parse(msg.content.toString());
+	return content.resource === 'babula';
+}
+bob.setup.chuckle.toReturn('chuckling');
+bob.setup.chuckle.when(tatulaMatchingPredicate).toReturn('chuckle talula');
+bob.setup.chuckle.when(babulaMatchingPredicate).toReturn('chuckle babula');
+
+var matchingMsg = {
+	//...
+	//other properties that we do not know until runtime
+	//...
+	content: new Buffer(JSON.stringify({
+		resource: 'talula'
+	}))
+};
+bob.chuckle(matchingMsg).should.eql('chuckle talula');
+matchingMsg.content.resource = 'babula';
+bob.chuckle(matchingMsg).should.eql('chuckle babula');
 ```
 
 

--- a/lib/deride.js
+++ b/lib/deride.js
@@ -99,7 +99,7 @@ function Expectations(obj, method) {
             assert.fail(calledWithArgs, pattern, 'Expected ' + method + ' to be called matching: ' + pattern);
         }
     }
-    
+
     function matchExactly() {
         var expectedArgs = _.values(arguments);
         var matched = true;
@@ -117,7 +117,7 @@ function Expectations(obj, method) {
             assert.fail(calledWithArgs, expectedArgs, 'Expected ' + method + ' to be called matchExactly args' + require('util').inspect(expectedArgs, {depth: 10}));
         }
     }
-    
+
     function objectPatternMatchProperties(obj, pattern) {
         var matched = false;
         _.deepMapValues(obj, function(i) {
@@ -261,8 +261,8 @@ function Setup(obj, method, emitter) {
     var callToInvoke = normalCall;
     var callToInvokeOnArguments = {};
     var argumentsPredicate;
-    var callBasedOnPredicate;
-    var predicate;
+    var lastPredicate;
+    var functionPredicates = [];
     var beforeFunc;
 
     function interceptCall(func) {
@@ -284,8 +284,13 @@ function Setup(obj, method, emitter) {
         if (_.isFunction(callBasedOnArgs)) {
             return callBasedOnArgs.apply(self, arguments);
         }
-        if (_.isFunction(callBasedOnPredicate)) {
-            return callBasedOnPredicate.apply(self, arguments);
+
+        var args = arguments;
+        var matchingPredicateTuple = functionPredicates.find(function(tuple){
+            return tuple[0].apply(self, args);
+        });
+        if (matchingPredicateTuple) {
+            return matchingPredicateTuple[1].apply(self, arguments);
         }
         return callToInvoke.apply(self, arguments);
     }
@@ -374,7 +379,7 @@ function Setup(obj, method, emitter) {
 
     function when() {
         if (_.isFunction(arguments['0'])) {
-            predicate = arguments['0'];
+            lastPredicate = arguments['0'];
         } else {
             argumentsPredicate = arguments;
         }
@@ -386,17 +391,8 @@ function Setup(obj, method, emitter) {
             var key = serializeArgs(argumentsPredicate);
             callToInvokeOnArguments[key] = func;
         } else {
-            if (_.isFunction(predicate)) {
-                callBasedOnPredicate = function() {
-                    debug('check predicate');
-                    if (predicate.apply(self, arguments)) {
-                        debug('predicate true');
-                        return func.apply(self, arguments);
-                    } else {
-                        debug('predicate false');
-                        return callToInvoke.apply(self, arguments);
-                    }
-                };
+            if (_.isFunction(lastPredicate)) {
+                functionPredicates.push([lastPredicate, func]);
             } else {
                 callToInvoke = func;
             }

--- a/test/test-deride.js
+++ b/test/test-deride.js
@@ -238,7 +238,7 @@ describe('Expectations', function() {
 
         describe('should not allow mutation after expectation is defined', function () {
             var bob, objectToMutate;
-            
+
             beforeEach(function () {
                 bob = deride.stub(['greet']);
                 objectToMutate = {
@@ -520,7 +520,7 @@ var tests = [{
         };
 
         return deride.wrap(new Person('bob proto'));
-    }   
+    }
 }];
 
 _.forEach(tests, function(test) {
@@ -635,7 +635,7 @@ _.forEach(tests, function(test) {
             bob.expect.greet.called.matchExactly(func);
         });
     });
-    
+
     describe(test.name + ':invocation', function() {
         beforeEach(function(done) {
             bob = test.setup();
@@ -1024,6 +1024,39 @@ _.forEach(tests, function(test) {
                         }))
                     };
                     bob.chuckle(matchingMsg).should.eql('chuckle talula');
+                });
+
+                it('still allows non-function predicates', function() {
+                    bob.chuckle('alice').should.eql('chuckle alice');
+                });
+            });
+
+            describe('multiple predicates', function() {
+                function bobMatchingPredicate(who) {
+                    return who === 'bob';
+                }
+
+                function charlieMatchingPredicate(who) {
+                    return who === 'charlie';
+                }
+
+                beforeEach(function() {
+                    bob.setup.chuckle.toReturn('chuckling');
+                    bob.setup.chuckle.when('alice').toReturn('chuckle alice');
+                    bob.setup.chuckle.when(bobMatchingPredicate).toReturn('chuckle bob');
+                    bob.setup.chuckle.when(charlieMatchingPredicate).toReturn('chuckle charlie');
+                });
+
+                it('non matching predicate returns existing response', function() {
+                    bob.chuckle('dan').should.eql('chuckling');
+                });
+
+                it('matching first predicate returns overriden response', function() {
+                    bob.chuckle('bob').should.eql('chuckle bob');
+                });
+
+                it('matching second predicate returns overriden response', function() {
+                    bob.chuckle('charlie').should.eql('chuckle charlie');
                 });
 
                 it('still allows non-function predicates', function() {


### PR DESCRIPTION
I have the need to use multiple predicates on the same method (`HttpClient.post()` called with different arguments).

## TODO

- [x] Write tests
- [x] Update docs