### PR TITLE
fix(ci): release from master only and stop pushing back to the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, master]
   pull_request:
-    branches: [develop, main]
+    branches: [develop, master]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [develop, main]
+    branches: [master]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -10,14 +11,15 @@ concurrency:
 
 jobs:
   release:
-    # Skip when the commit was made by semantic-release itself (chore(release))
+    # Skip commits semantic-release would produce itself (belt-and-braces —
+    # we no longer commit back to master, but leave the guard in place).
     if: "!contains(github.event.head_commit.message, 'chore(release):')"
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      issues: write
+      contents: write        # creating git tags and GitHub releases
+      issues: write          # semantic-release opens issues on failure
       pull-requests: write
-      id-token: write
+      id-token: write        # npm provenance
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,8 +33,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
 
-      # Re-run the full gate before publishing so we never ship a red build,
-      # even if somebody pushed directly past the branch protection.
+      # Re-run the gate before publishing so a red build never reaches npm,
+      # even if somebody merged past branch protection.
       - name: Lint
         run: pnpm lint
       - name: Typecheck

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main", "develop"],
+  "branches": ["master"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",
@@ -33,15 +33,8 @@
         ]
       }
     }],
-    ["@semantic-release/changelog", {
-      "changelogFile": "CHANGELOG.md"
-    }],
     ["@semantic-release/npm", {
       "npmPublish": true
-    }],
-    ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {
       "successComment": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-All notable changes to this project are documented in this file.
+All notable changes to this project are documented in the **[GitHub releases page](https://github.com/guzzlerio/deride/releases)**, generated automatically by [semantic-release](https://github.com/semantic-release/semantic-release) from [Conventional Commits](https://www.conventionalcommits.org/).
 
-From v2.1 onwards this file is maintained automatically by
-[semantic-release](https://github.com/semantic-release/semantic-release)
-based on [Conventional Commits](https://www.conventionalcommits.org/).
+This file preserves the historical v2.0.0 notes only; check the releases page for everything from v2.1 onwards.
 
 ## 2.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,15 +55,34 @@ echo "feat(matchers): add match.bigint" | pnpm commitlint
 
 ## Releases
 
-Releases are fully automated by [semantic-release](https://github.com/semantic-release/semantic-release):
+Releases are scoped to the `master` branch. This keeps work on `develop`
+accumulating without every merge triggering a publish.
 
-- CI runs on every push to `develop` / `main`.
-- If any of the commits since the last tag are release-worthy, semantic-release
-  computes the next version, updates `CHANGELOG.md` and `package.json`, tags the
-  commit, publishes to npm with provenance, and creates a GitHub release.
-- Nothing to do manually — just land conventional commits.
+**Branch roles:**
 
-To preview what a branch would release:
+| Branch | Role |
+|--------|------|
+| `develop` | Default integration branch. All PRs target it. |
+| `master` | Release branch. Merging `develop` → `master` cuts a release. |
+| `feature/*`, `fix/*` | Work branches, PR'd into `develop`. |
+
+**Cutting a release:**
+
+1. Land the relevant conventional-commit PRs on `develop`.
+2. Open a PR from `develop` → `master` (or fast-forward if preferred).
+3. Merge it. [semantic-release](https://github.com/semantic-release/semantic-release) runs automatically on `master`:
+   - computes the next version from the commits since the last tag,
+   - creates the git tag,
+   - publishes to npm with provenance,
+   - posts a GitHub release with auto-generated notes.
+4. Nothing to do manually.
+
+`package.json` and `CHANGELOG.md` in the repo are **not** auto-updated —
+branch protection would require us to push a commit back, which we
+deliberately don't do. Authoritative release history lives on the
+[GitHub Releases page](https://github.com/guzzlerio/deride/releases).
+
+To preview what a merge would release:
 
 ```bash
 pnpm release:dry-run


### PR DESCRIPTION
## Summary

The v2.1.0 release attempt on \`develop\` failed for two reasons — this PR fixes both.

## What went wrong

1. **Wrong version computed (\`1.4.0\` instead of \`2.1.0\`).** \`.releaserc.json\` listed \`\"main\"\` as a release branch, but \`main\` doesn't exist in this repo. semantic-release got confused about which tag line to continue.

2. **Branch-protection rejected the git push.** The \`@semantic-release/git\` plugin tries to commit \`chore(release):\` back to the branch it's releasing from. Branch protection on \`develop\` blocks direct pushes:
   > GH006: Protected branch update failed for refs/heads/develop.
   > Changes must be made through a pull request.

## What this PR changes

- **Releases now come from \`master\` only.** \`develop\` is the integration trunk; merging \`develop\` → \`master\` cuts a release. This is the git-flow pattern the maintainers actually want. Saved as a project memory so future sessions don't get this wrong again.
- **Dropped \`@semantic-release/git\` and \`@semantic-release/changelog\`** — the committed \`package.json\` and \`CHANGELOG.md\` don't need auto-updating, and they'd keep fighting branch protection if they did. Authoritative release history lives on the [GitHub Releases page](https://github.com/guzzlerio/deride/releases) (generated by \`release-notes-generator\`). Tags and npm publish still happen via the remaining plugins.
- **\`.github/workflows/release.yml\`** now triggers on push to \`master\` only.
- **\`.github/workflows/ci.yml\`** adds \`master\` to the push/PR trigger lists.
- **\`CONTRIBUTING.md\`** documents the \"merge develop → master to release\" flow explicitly.
- **\`CHANGELOG.md\`** header points readers at the GH Releases page for v2.1+ notes.

## After this lands

1. Merge this PR to \`develop\`.
2. Open a PR from \`develop\` → \`master\` containing the v2.1 feature set (PR #86's work plus whatever else is on develop).
3. Merge that. \`release.yml\` runs on \`master\`, publishes \`v2.1.0\` to npm, creates the tag and GitHub release.

## Test plan

- [ ] CI (\`Docs\`, \`CI Pass\`) goes green on this PR
- [ ] \`release-dry-run\` job on this PR's CI shows either \"no release\" (expected — this PR targets develop, and \`master\` is the only release branch) or the predicted bump if we test it against master
- [ ] After merge to develop, nothing releases (develop isn't a release branch anymore)
- [ ] After follow-up merge to master, v2.1.0 publishes to npm and a tag/release appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)