### PR TITLE
docs(ai): add For Agents section, llms.txt feeds, and per-page .md variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,31 @@ Six variants in `brand/`:
 
 VitePress config uses `{ light, dark }` per-theme logo — no CSS filter hacks. If you need a new size/crop variant, regenerate from the originals with ImageMagick (see `brand/README.md`).
 
+## "For Agents" docs section (`docs/ai/`) — keep this current
+
+The docs site has a section written specifically for AI agents at `docs/ai/`. It exists because agent-generated code fails most often when the agent can't disambiguate between similar APIs (`stub` vs `wrap` vs `func`, `expect` vs `spy`, which setup for which task). The section captures those decisions explicitly so agents have an authoritative source.
+
+**Pages you must keep synced whenever the main guide changes:**
+
+| Guide change | Also update |
+|--------------|-------------|
+| New factory or new setup method | `docs/ai/decision-tree.md` (add row), `docs/ai/canonical-examples.md` if it's a common pattern |
+| New matcher | `docs/ai/decision-tree.md` → "which matcher" table |
+| New expectation method | `docs/ai/decision-tree.md` → "which expect" table |
+| Change to an existing idiomatic pattern | `docs/ai/canonical-examples.md` (update the blessed snippet) |
+| Discovered anti-pattern / common footgun | `docs/ai/common-mistakes.md` (add entry with wrong/right) |
+| New sub-path export | `docs/ai/decision-tree.md` + `docs/ai/feeds.md` if discoverability changes |
+
+**Feed infrastructure** — `docs/.vitepress/emit-llm-assets.ts` runs on every build and emits:
+
+- `dist/<page>.md` — a clean Markdown copy of every page
+- `dist/llms.txt` — [llmstxt.org](https://llmstxt.org) index (sorted, grouped)
+- `dist/llms-full.txt` — all pages concatenated
+
+Adding a new page under `docs/` picks up automatically. If you move or rename a page, verify the feeds still include it (check `pnpm docs:build` log output).
+
+**The deal:** AI-authored PRs that change an API but leave the `docs/ai/` pages stale should be held in review until they're synced. Human contributors are encouraged to do the same but there's no CI enforcement (we could add one — grep `docs/ai/*.md` for every public export; not done yet).
+
 ## Things to avoid
 
 - **Don't add runtime dependencies beyond `debug`.** The 15 KB footprint claim was deliberate; keep the package lean.
@@ -129,7 +154,15 @@ VitePress config uses `{ light, dark }` per-theme logo — no CSS filter hacks. 
 
 - [README.md](./README.md) — user-facing overview, API summary, examples
 - [CONTRIBUTING.md](./CONTRIBUTING.md) — commit rules, scripts, release steps
-- [docs/](./docs/) — VitePress site source (guide, API reference, recipes)
+- [docs/](./docs/) — VitePress site source (guide, API reference, recipes, for-agents)
+- [docs/ai/](./docs/ai/) — pages written for AI agent consumption — sync these with the guide
+- [docs/.vitepress/emit-llm-assets.ts](./docs/.vitepress/emit-llm-assets.ts) — build hook that emits llms.txt + .md variants
 - [brand/README.md](./brand/README.md) — brand asset usage
 - [.releaserc.json](./.releaserc.json) — release rules
 - [.github/workflows/](./.github/workflows/) — CI (`ci.yml`), release (`release.yml`), docs (`docs.yml`)
+
+## Published feeds (for pointing agents at)
+
+- <https://guzzlerio.github.io/deride/llms.txt> — llmstxt.org index
+- <https://guzzlerio.github.io/deride/llms-full.txt> — all docs concatenated
+- Any page `.md` variant, e.g. <https://guzzlerio.github.io/deride/guide/quick-start.md>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import { emitLlmAssets } from './emit-llm-assets'
 
 export default defineConfig({
   title: 'deride',
@@ -35,6 +36,7 @@ export default defineConfig({
       { text: 'Integrations', link: '/integrations/vitest', activeMatch: '^/integrations/' },
       { text: 'API', link: '/api/', activeMatch: '^/api/' },
       { text: 'Recipes', link: '/recipes/module-mocking', activeMatch: '^/recipes/' },
+      { text: 'For Agents', link: '/ai/', activeMatch: '^/ai/' },
       {
         text: 'Links',
         items: [
@@ -118,6 +120,18 @@ export default defineConfig({
           ],
         },
       ],
+      '/ai/': [
+        {
+          text: 'For Agents',
+          items: [
+            { text: 'Overview', link: '/ai/' },
+            { text: 'Decision tree', link: '/ai/decision-tree' },
+            { text: 'Canonical examples', link: '/ai/canonical-examples' },
+            { text: 'Common mistakes', link: '/ai/common-mistakes' },
+            { text: 'Agent-ready feeds', link: '/ai/feeds' },
+          ],
+        },
+      ],
     },
 
     socialLinks: [
@@ -156,5 +170,12 @@ export default defineConfig({
   markdown: {
     theme: { light: 'github-light', dark: 'github-dark' },
     lineNumbers: false,
+  },
+
+  // After the static HTML is built, emit:
+  //   - a .md copy of every page next to the .html
+  //   - /llms.txt and /llms-full.txt per llmstxt.org
+  async buildEnd(siteConfig) {
+    await emitLlmAssets(siteConfig)
   },
 })

--- a/docs/.vitepress/emit-llm-assets.ts
+++ b/docs/.vitepress/emit-llm-assets.ts
@@ -1,0 +1,250 @@
+/**
+ * VitePress buildEnd hook — emits three classes of machine-readable artefact
+ * into `dist/` alongside the built HTML:
+ *
+ *  1. A `.md` copy of every source page (so consumers can fetch the Markdown
+ *     directly by appending `.md` to any URL).
+ *  2. `/llms.txt` — the llmstxt.org-format short index: project description
+ *     plus a linked list of every page with a one-line summary.
+ *  3. `/llms-full.txt` — every page's markdown, concatenated with section
+ *     separators, stripped of YAML frontmatter. For agents that want to load
+ *     the whole docs in one fetch.
+ *
+ * No runtime deps beyond `node:fs` / `node:path` / `node:url`.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import type { SiteConfig } from 'vitepress'
+
+interface PageRecord {
+  /** Repo-relative source path, e.g. "docs/guide/quick-start.md" */
+  src: string
+  /** URL-facing route under the site base, e.g. "/guide/quick-start" */
+  route: string
+  /** Filename path under dist, e.g. "guide/quick-start.md" */
+  distRelative: string
+  /** First-line title (from the first `# ` header, falling back to route). */
+  title: string
+  /** Frontmatter description if present, else first paragraph. */
+  summary: string
+  /** Full source markdown, frontmatter removed. */
+  body: string
+}
+
+const BASE = process.env.DERIDE_BASE ?? '/deride/'
+const SITE_URL = 'https://guzzlerio.github.io/deride'
+
+/** Strip leading YAML frontmatter (`---\n...\n---\n`). */
+function stripFrontmatter(md: string): { body: string; frontmatter: Record<string, string> } {
+  const match = md.match(/^---\n([\s\S]*?)\n---\n/)
+  if (!match) return { body: md, frontmatter: {} }
+  const frontmatter: Record<string, string> = {}
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^(\w+):\s*(.*)$/)
+    if (m) frontmatter[m[1]] = m[2].trim()
+  }
+  return { body: md.slice(match[0].length), frontmatter }
+}
+
+function extractTitle(body: string, fallback: string): string {
+  const m = body.match(/^#\s+(.+)$/m)
+  return m ? m[1].trim() : fallback
+}
+
+function extractSummary(body: string, frontmatter: Record<string, string>): string {
+  if (frontmatter.tagline) return frontmatter.tagline
+  if (frontmatter.description) return frontmatter.description
+  // First non-heading, non-blank paragraph.
+  const paragraphs = body
+    .replace(/^---[\s\S]*?---\n/, '')
+    .split(/\n\n+/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+  for (const p of paragraphs) {
+    if (p.startsWith('#')) continue
+    if (p.startsWith('```')) continue
+    // Strip simple markdown syntax — agents read raw text fine, but
+    // a cleaner summary reads better in llms.txt.
+    return p
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .split('\n')[0]
+      .slice(0, 200)
+  }
+  return ''
+}
+
+/** Walk `srcDir` recursively for `.md` files, excluding internal VitePress dirs. */
+function* walkMarkdown(srcDir: string, base = ''): Generator<string> {
+  const entries = fs.readdirSync(path.join(srcDir, base), { withFileTypes: true })
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue // .vitepress, .obsidian, etc.
+    const rel = path.join(base, entry.name)
+    const abs = path.join(srcDir, rel)
+    if (entry.isDirectory()) {
+      yield* walkMarkdown(srcDir, rel)
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      yield rel
+    }
+  }
+}
+
+function routeFor(rel: string): string {
+  // docs/guide/quick-start.md -> /guide/quick-start
+  // docs/index.md -> /
+  // docs/api/index.md -> /api/
+  let r = rel.replace(/\\/g, '/').replace(/\.md$/, '')
+  if (r === 'index') return '/'
+  if (r.endsWith('/index')) r = r.slice(0, -'index'.length)
+  return '/' + r
+}
+
+function collect(srcDir: string): PageRecord[] {
+  const pages: PageRecord[] = []
+  for (const rel of walkMarkdown(srcDir)) {
+    const abs = path.join(srcDir, rel)
+    const raw = fs.readFileSync(abs, 'utf8')
+    const { body, frontmatter } = stripFrontmatter(raw)
+    const route = routeFor(rel)
+    const title = frontmatter.title
+      ? frontmatter.title
+      : frontmatter.name
+        ? frontmatter.name
+        : extractTitle(body, route)
+    const summary = extractSummary(body, frontmatter)
+    pages.push({
+      src: rel,
+      route,
+      distRelative: rel.replace(/\\/g, '/'),
+      title,
+      summary,
+      body: body.trim() + '\n',
+    })
+  }
+  // Sort: home first, then alphabetical by route.
+  pages.sort((a, b) => {
+    if (a.route === '/') return -1
+    if (b.route === '/') return 1
+    return a.route.localeCompare(b.route)
+  })
+  return pages
+}
+
+function urlFor(route: string, ext: '.md' | '' = ''): string {
+  const base = BASE.endsWith('/') ? BASE.slice(0, -1) : BASE
+  if (route === '/') return `${SITE_URL}${base}/${ext ? `index${ext}` : ''}`
+  if (route.endsWith('/') && ext === '.md') {
+    return `${SITE_URL}${base}${route}index${ext}`
+  }
+  return `${SITE_URL}${base}${route}${ext}`
+}
+
+function groupPages(pages: PageRecord[]): Record<string, PageRecord[]> {
+  const groups: Record<string, PageRecord[]> = {
+    Home: [],
+    Guide: [],
+    'For Agents': [],
+    Integrations: [],
+    'API reference': [],
+    Recipes: [],
+  }
+  for (const p of pages) {
+    if (p.route === '/') groups.Home.push(p)
+    else if (p.route.startsWith('/guide/')) groups.Guide.push(p)
+    else if (p.route.startsWith('/ai/')) groups['For Agents'].push(p)
+    else if (p.route.startsWith('/integrations/')) groups.Integrations.push(p)
+    else if (p.route.startsWith('/api/')) groups['API reference'].push(p)
+    else if (p.route.startsWith('/recipes/')) groups.Recipes.push(p)
+    else (groups.Home ||= []).push(p)
+  }
+  return groups
+}
+
+function renderLlmsTxt(pages: PageRecord[]): string {
+  const groups = groupPages(pages)
+  const lines: string[] = []
+  lines.push('# deride')
+  lines.push('')
+  lines.push('> TypeScript-first mocking library that wraps rather than monkey-patches. Works with frozen objects, sealed classes, and any coding style.')
+  lines.push('')
+  lines.push('Zero runtime dependencies beyond `debug`. Ships ESM + CJS + `.d.ts`. Framework-agnostic; opt-in integrations for vitest / jest / fake timers via sub-paths.')
+  lines.push('')
+  lines.push('This site also publishes:')
+  lines.push('')
+  lines.push(`- [\`llms-full.txt\`](${SITE_URL}${BASE}llms-full.txt) — every page concatenated for single-fetch ingestion.`)
+  lines.push(`- \`.md\` variants of every page (append \`.md\` to any URL, e.g. ${SITE_URL}${BASE}guide/quick-start.md).`)
+  lines.push(`- Decision tree, common mistakes, and canonical examples under the [For Agents](${SITE_URL}${BASE}ai/) section.`)
+  lines.push('')
+  for (const [heading, items] of Object.entries(groups)) {
+    if (items.length === 0 || heading === 'Home') continue
+    lines.push(`## ${heading}`)
+    lines.push('')
+    for (const p of items) {
+      const summary = p.summary ? `: ${p.summary}` : ''
+      lines.push(`- [${p.title}](${urlFor(p.route, '.md')})${summary}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
+function renderLlmsFullTxt(pages: PageRecord[]): string {
+  const groups = groupPages(pages)
+  const parts: string[] = []
+  parts.push('# deride — complete documentation')
+  parts.push('')
+  parts.push('> TypeScript-first mocking library that wraps rather than monkey-patches. Works with frozen objects, sealed classes, and any coding style.')
+  parts.push('')
+  parts.push('This file concatenates every documentation page. For the structured index, see `llms.txt`. For individual pages as markdown, append `.md` to any URL.')
+  parts.push('')
+  for (const [heading, items] of Object.entries(groups)) {
+    if (items.length === 0) continue
+    parts.push('═'.repeat(78))
+    parts.push(`# ${heading}`)
+    parts.push('═'.repeat(78))
+    parts.push('')
+    for (const p of items) {
+      parts.push('─'.repeat(78))
+      parts.push(`# ${p.title}`)
+      parts.push(`Source: ${urlFor(p.route, '.md')}`)
+      parts.push('─'.repeat(78))
+      parts.push('')
+      // The body already has its own `# Title` heading — dedupe by stripping the first one if present.
+      const body = p.body.replace(/^#\s+.+\n+/, '')
+      parts.push(body)
+      parts.push('')
+    }
+  }
+  return parts.join('\n')
+}
+
+/**
+ * Main entry — called from config.ts's `buildEnd` hook with the resolved SiteConfig.
+ */
+export async function emitLlmAssets(siteConfig: SiteConfig): Promise<void> {
+  const srcDir = siteConfig.srcDir
+  const outDir = siteConfig.outDir
+
+  const pages = collect(srcDir)
+  if (pages.length === 0) return
+
+  // 1. Write .md copies of every source page next to the HTML.
+  for (const p of pages) {
+    const dest = path.join(outDir, p.distRelative)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, p.body, 'utf8')
+  }
+
+  // 2. llms.txt — index for agents
+  fs.writeFileSync(path.join(outDir, 'llms.txt'), renderLlmsTxt(pages), 'utf8')
+
+  // 3. llms-full.txt — concatenated body of every page
+  fs.writeFileSync(path.join(outDir, 'llms-full.txt'), renderLlmsFullTxt(pages), 'utf8')
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `  [llm-assets] wrote ${pages.length} .md variants, llms.txt (${(fs.statSync(path.join(outDir, 'llms.txt')).size / 1024).toFixed(1)} KB), llms-full.txt (${(fs.statSync(path.join(outDir, 'llms-full.txt')).size / 1024).toFixed(1)} KB)`
+  )
+}

--- a/docs/ai/canonical-examples.md
+++ b/docs/ai/canonical-examples.md
@@ -1,0 +1,260 @@
+# Canonical examples
+
+One blessed idiomatic snippet per common task. **Use these verbatim**; they're the shape the library is designed around. If an agent-generated solution strays from these patterns, assume the agent is confused and redirect to the closest pattern here.
+
+## 1. Mock an async service, inject, assert
+
+**Task:** test a service that depends on a database.
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { stub, match } from 'deride'
+
+interface Database {
+  query(sql: string): Promise<unknown[]>
+  findById(id: number): Promise<unknown>
+}
+
+class UserService {
+  constructor(private db: Database) {}
+  async listActive() { return this.db.query("SELECT * FROM users WHERE active") }
+}
+
+describe('UserService', () => {
+  it('queries the active users', async () => {
+    const mockDb = stub<Database>(['query', 'findById'])
+    mockDb.setup.query.toResolveWith([{ id: 1, name: 'alice' }])
+
+    const service = new UserService(mockDb)
+    const users = await service.listActive()
+
+    expect(users).toHaveLength(1)
+    mockDb.expect.query.called.once()
+    mockDb.expect.query.called.withArg(match.regex(/active/i))
+  })
+})
+```
+
+## 2. Different returns per call
+
+**Task:** a paginated fetch where each call returns the next page.
+
+```typescript
+mock.setup.fetchPage.toResolveInOrder(
+  { page: 1, rows: ['a'] },
+  { page: 2, rows: ['b'] },
+  { page: 3, rows: ['c'] },
+)
+// 4th call: sticky-last (page 3 again)
+// OR explicit fallback:
+mock.setup.fetchPage.toResolveInOrder(
+  [{ page: 1 }, { page: 2 }],
+  { then: null },
+)
+```
+
+## 3. Conditional behaviour on args
+
+**Task:** return different data depending on what the code under test asks for.
+
+```typescript
+mock.setup.findById.when(1).toResolveWith({ id: 1, name: 'alice' })
+mock.setup.findById.when(match.gte(9999)).toRejectWith(new Error('not found'))
+// Default fallthrough — any other id returns undefined
+```
+
+## 4. Error / timeout paths
+
+**Task:** verify the code handles a timeout or rejection correctly.
+
+```typescript
+// Rejected promise
+mock.setup.fetch.toRejectWith(new Error('network'))
+await expect(service.loadData()).rejects.toThrow('network')
+
+// Never-settling promise — for testing timeout logic
+mock.setup.fetch.toHang()
+const result = await Promise.race([
+  service.loadData(),
+  new Promise((r) => setTimeout(() => r('TIMEOUT'), 100)),
+])
+```
+
+## 5. Fluent / chainable API (query builder, etc.)
+
+**Task:** mock a chain-of-methods API.
+
+```typescript
+interface Query {
+  where(s: string): Query
+  orderBy(s: string): Query
+  execute(): Promise<unknown[]>
+}
+
+const q = stub<Query>(['where', 'orderBy', 'execute'])
+q.setup.where.toReturnSelf()
+q.setup.orderBy.toReturnSelf()
+q.setup.execute.toResolveWith([{ id: 1 }])
+
+const rows = await q.where('active').orderBy('name').execute()
+```
+
+## 6. Mock a constructor call (`new X(...)`)
+
+**Task:** code under test does `new Database(conn)` and you need to intercept both the construction and the instance's methods.
+
+```typescript
+import { stub } from 'deride'
+import { Database } from './database'
+
+const MockedDb = stub.class(Database)
+MockedDb.setupAll((inst) => inst.setup.query.toResolveWith([]))
+
+// Substitute the constructor at import time — test-runner specific
+vi.mock('./database', () => ({ Database: MockedDb }))
+
+// ... run code under test ...
+
+MockedDb.expect.constructor.called.withArg('my-conn-string')
+MockedDb.instances[0].expect.query.called.once()
+```
+
+## 7. Partial mock — real methods by default, override one
+
+**Task:** spy on some methods of a real object while keeping others running.
+
+```typescript
+const realLogger = { info: (m: string) => console.log(m), error: (m: string) => console.error(m) }
+
+const wrapped = wrap(realLogger)
+wrapped.info('hello')                           // runs real console.log
+wrapped.setup.error.toDoThis(() => {})          // silence errors in the test
+wrapped.error('boom')                           // no output; recorded
+wrapped.expect.error.called.withArg('boom')
+```
+
+## 8. Standalone mocked function (callback or fetcher)
+
+**Task:** the code under test takes a function as a parameter.
+
+```typescript
+import { func } from 'deride'
+
+const onTick = func<(frame: number) => void>()
+animator.subscribe(onTick)
+animator.step()
+animator.step()
+
+onTick.expect.called.twice()
+onTick.expect.invocation(0).withArg(0)
+onTick.expect.invocation(1).withArg(1)
+```
+
+## 9. Cross-mock call ordering
+
+**Task:** assert a specific sequence of calls across multiple mocks.
+
+```typescript
+import { inOrder } from 'deride'
+
+await repository.load()
+
+inOrder(
+  db.spy.connect,
+  db.spy.query,
+  logger.spy.info,
+)
+```
+
+For strict interleave (no other calls on listed spies between them), use `inOrder.strict(...)`.
+
+## 10. Read a captured return value forward
+
+**Task:** the code returned a Promise; you want to await its settled value in the test.
+
+```typescript
+mock.setup.fetch.toResolveWith({ id: 1 })
+mock.fetch('/x')
+
+const data = await mock.spy.fetch.lastCall!.returned as Promise<{ id: number }>
+expect(await data).toEqual({ id: 1 })
+```
+
+Note: `expect.called.withReturn({ id: 1 })` asserts the value was returned, but can't hand it back. Use `spy.lastCall.returned` when you need the value for further assertions.
+
+## 11. Sandbox pattern for test lifecycle
+
+**Task:** many mocks per test file, reset between tests, full restore at end.
+
+```typescript
+import { sandbox } from 'deride'
+
+const sb = sandbox()
+
+beforeEach(() => {
+  mockDb = sb.stub<Database>(['query'])
+  mockLog = sb.wrap(realLogger)
+})
+
+afterEach(() => sb.reset())       // call history cleared, setups preserved
+afterAll(() => sb.restore())      // full wipe (setups + history)
+```
+
+## 12. Fake timers for delayed async
+
+**Task:** test a retry loop with backoff.
+
+```typescript
+import { useFakeTimers, isFakeTimersActive, restoreActiveClock } from 'deride/clock'
+import { afterEach } from 'vitest'
+
+afterEach(() => { if (isFakeTimersActive()) restoreActiveClock() })
+
+it('retries twice then succeeds', async () => {
+  const clock = useFakeTimers()
+  const fn = func<() => Promise<string>>()
+  fn.setup.toRejectInOrder(new Error('1'), new Error('2'))
+  fn.setup.toResolveWith('ok')
+
+  const p = withRetry(fn, 5, 100)
+
+  for (let i = 0; i < 3; i++) {
+    await clock.flushMicrotasks()
+    clock.tick(100)
+  }
+
+  expect(await p).toBe('ok')
+  fn.expect.called.times(3)
+})
+```
+
+## 13. Vitest / jest matcher sugar
+
+**Task:** prefer framework-native assertion style.
+
+```typescript
+// test-setup.ts (referenced from vitest.config.ts setupFiles)
+import 'deride/vitest'
+
+// any test file:
+import { stub, match } from 'deride'
+const mock = stub<Service>(['handle'])
+mock.handle(42)
+
+expect(mock.spy.handle).toHaveBeenCalledOnce()
+expect(mock.spy.handle).toHaveBeenCalledWith(match.number)
+expect(mock.spy.handle).toHaveBeenLastCalledWith(42)
+```
+
+For `jest`: replace `'deride/vitest'` with `'deride/jest'`. Everything else is identical.
+
+---
+
+## What NOT to generate
+
+- Don't `vi.spyOn(x, 'method')` and then try to use deride — pick one.
+- Don't mutate `mock.spy.calls[i].args` and expect the mock to "react" — those are records, not controls.
+- Don't `await mock.expect.x.called.withReturn(v)` — `expect` returns void, not a Promise.
+- Don't squash-merge a deride release PR — see the [CLAUDE.md](https://github.com/guzzlerio/deride/blob/develop/CLAUDE.md) at the repo root.
+
+Full list of anti-patterns and their fixes: [Common mistakes](/ai/common-mistakes).

--- a/docs/ai/common-mistakes.md
+++ b/docs/ai/common-mistakes.md
@@ -1,0 +1,262 @@
+# Common mistakes
+
+Anti-patterns agents tend to produce, and the correct shape. Each entry shows the **wrong** version first (the thing we see in the wild) and then the **right** version, with a short note on why.
+
+## 1. Mixing deride with `vi.spyOn` / `jest.spyOn`
+
+**❌ Wrong**
+
+```typescript
+const spy = vi.spyOn(realDb, 'query').mockResolvedValue([])
+// ... then trying to use deride on the same object ...
+realDb.expect.query.called.once()  // TypeError: realDb.expect is undefined
+```
+
+**✅ Right**
+
+```typescript
+const mockDb = wrap(realDb)
+mockDb.setup.query.toResolveWith([])
+await mockDb.query('…')
+mockDb.expect.query.called.once()
+```
+
+**Why:** pick one mocking tool per object. `vi.spyOn` monkey-patches the real object; deride composes a new object. Don't mix.
+
+## 2. Mutating `spy.calls[i].args` and expecting it to stick
+
+**❌ Wrong**
+
+```typescript
+mock.spy.greet.calls[0].args[0] = 'hacked'     // pointless — calls are immutable records
+mock.greet()                                    // does nothing different
+```
+
+**✅ Right**
+
+`spy.calls` is a read-only log. If you want the mock to return a different value, configure it via `setup.*`:
+
+```typescript
+mock.setup.greet.when('hacked').toReturn(…)
+```
+
+**Why:** `spy` is the **inspection** surface — it records what happened, it doesn't drive what happens next.
+
+## 3. Awaiting `expect.*` calls
+
+**❌ Wrong**
+
+```typescript
+await mock.expect.fetch.called.withReturn({ id: 1 })   // returns undefined; await is a no-op
+```
+
+**✅ Right**
+
+`expect.*` assertions are **synchronous** and return `void`. Don't `await` them.
+
+```typescript
+mock.expect.fetch.called.withReturn({ id: 1 })
+```
+
+If you specifically need to await a captured Promise to check its settled value, use `spy`:
+
+```typescript
+mock.setup.fetch.toResolveWith({ id: 1 })
+mock.fetch('/x')
+const promise = mock.spy.fetch.lastCall!.returned as Promise<{ id: number }>
+await expect(promise).resolves.toEqual({ id: 1 })
+```
+
+## 4. Using `@ts-ignore` or `@ts-expect-error` for intentional type escape hatches
+
+**❌ Wrong**
+
+```typescript
+// @ts-ignore
+mock.setup.fetch.toResolveWith(null)   // suppresses the type error with no visible marker
+```
+
+**✅ Right**
+
+```typescript
+mock.setup.fetch.toResolveWith(null as any)   // or: as unknown as string
+```
+
+**Why:** deride's idiomatic escape hatch is the `as any` / `as unknown as T` cast. It's grep-able, localised to the one call, and doesn't suppress *other* errors on the same line. `@ts-ignore` is too broad.
+
+## 5. Expecting `toReturn` to match TypeScript-narrowed types
+
+**❌ Wrong**
+
+```typescript
+interface Svc {
+  get(): Promise<string>
+}
+
+const mock = stub<Svc>(['get'])
+mock.setup.get.toReturn('value')   // type error — get returns Promise<string>, not string
+```
+
+**✅ Right**
+
+Use `toResolveWith` for Promise-returning methods — it unwraps the resolved type for you:
+
+```typescript
+mock.setup.get.toResolveWith('value')   // ✓ expects string (unwrapped from Promise<string>)
+```
+
+**Why:** `toReturn` takes the raw method return type. For `Promise<T>`-returning methods, `toResolveWith` takes `T`.
+
+## 6. Using `toReturn` when the method expects a Promise rejection
+
+**❌ Wrong**
+
+```typescript
+mock.setup.fetch.toReturn(Promise.reject(new Error('x')))   // creates an unhandled rejection
+```
+
+**✅ Right**
+
+```typescript
+mock.setup.fetch.toRejectWith(new Error('x'))
+```
+
+**Why:** `toRejectWith` constructs the rejection internally when the method is invoked, so there's no unhandled-rejection window.
+
+## 7. Forgetting the dispatch rule — later unlimited wins
+
+**❌ Wrong**
+
+```typescript
+mock.setup.x.when('admin').toReturn('hi admin')   // registered FIRST
+mock.setup.x.toReturn('default')                   // registered LAST — this wins
+
+mock.x('admin')   // returns 'default' (!), not 'hi admin'
+```
+
+**✅ Right**
+
+Time-limit the conditional behaviour so it beats the later default:
+
+```typescript
+mock.setup.x.when('admin').toReturn('hi admin').once()   // consumed first
+mock.setup.x.toReturn('default')                          // fallback after
+```
+
+**Why:** the dispatch rule is "time-limited first (FIFO), then last unlimited wins." Registering a general default AFTER a specific `when(...)` shadows the `when`. See [Philosophy](/guide/philosophy#the-dispatch-rule).
+
+## 8. Constructing `new MockedClass()` in the test without substituting the real import
+
+**❌ Wrong**
+
+```typescript
+const MockedDb = stub.class(Database)
+const service = new UserService()   // UserService internally does `new Database(conn)` — uses the REAL class
+MockedDb.expect.constructor.called.once()   // fails — the real constructor ran
+```
+
+**✅ Right**
+
+`stub.class` gives you a mock *constructor*, but your code imports the real one. Substitute at the module boundary:
+
+```typescript
+const MockedDb = stub.class(Database)
+
+vi.mock('./database', () => ({ Database: MockedDb }))
+// or jest.mock / mock.module for your runner
+
+const service = new UserService()   // now uses MockedDb
+MockedDb.expect.constructor.called.once()   // ✓
+```
+
+**Why:** `stub.class` is a **drop-in replacement**, but you still need to drop it in.
+
+## 9. `withArg` with a deep-nested matcher that doesn't recurse
+
+**❌ Wrong assumption**
+
+```typescript
+mock.x([{ id: 1, nested: { code: 'ok' } }])
+mock.expect.x.called.withArg([match.objectContaining({ nested: match.objectContaining({ code: 'ok' }) })])
+// THIS works — matchers nest
+```
+
+But sometimes agents write:
+
+```typescript
+mock.expect.x.called.withArg([{ nested: { code: 'ok' } }])   // deep-equal comparison, no matchers
+```
+
+**Both work** — deride's `hasMatch` does deep equality for non-matcher leaves. The pitfall is expecting matchers to *implicitly* appear in nested structures when you used a literal.
+
+**Rule:** if you want matcher behaviour at depth, spell it out. If you want exact equality at depth, pass literals.
+
+## 10. Squash-merging a release PR
+
+**❌ Wrong**
+
+Clicking "Squash and merge" on a `develop` → `master` PR titled `release: v2.1`. The squash collapses every `feat:` / `fix:` into a single commit whose message is the PR title. `release:` isn't a conventional-commit type the release rules recognise → semantic-release says "no release" → nothing publishes.
+
+**✅ Right**
+
+Use **"Create a merge commit"** or **"Rebase and merge"**. Both preserve the individual conventional commits so semantic-release can compute the correct version.
+
+**Why:** semantic-release reads the conventional-commit types from each commit since the last tag. Squash loses them unless you rename the squash commit to a conventional type at merge time.
+
+## 11. Running `deride/vitest` or `deride/jest` without loading them via `setupFiles`
+
+**❌ Wrong**
+
+```typescript
+// vitest.config.ts
+export default defineConfig({ test: {} })   // nothing imports deride/vitest
+
+// my.test.ts
+expect(mock.spy.greet).toHaveBeenCalledOnce()   // matcher not registered — fails with "unknown matcher"
+```
+
+**✅ Right**
+
+```typescript
+// vitest.setup.ts
+import 'deride/vitest'
+
+// vitest.config.ts
+export default defineConfig({
+  test: { setupFiles: ['./vitest.setup.ts'] }
+})
+```
+
+**Why:** `deride/vitest` registers matchers via `expect.extend(...)` as a side effect at module load. The matchers live on whatever `expect` was in scope when the import ran. Loading it via `setupFiles` ensures they're available in every test.
+
+## 12. Forgetting `restoreActiveClock` in `afterEach`
+
+**❌ Wrong**
+
+```typescript
+it('does timing stuff', () => {
+  const clock = useFakeTimers()
+  clock.runAll()   // throws if setInterval loops — restore() never runs
+})
+it('next test', () => {
+  // Date.now is still frozen, setTimeout is still fake
+})
+```
+
+**✅ Right**
+
+```typescript
+import { afterEach } from 'vitest'
+import { isFakeTimersActive, restoreActiveClock, useFakeTimers } from 'deride/clock'
+
+afterEach(() => {
+  if (isFakeTimersActive()) restoreActiveClock()
+})
+
+it('does timing stuff', () => {
+  const clock = useFakeTimers()
+  clock.runAll()   // even if this throws, afterEach restores
+})
+```
+
+**Why:** `useFakeTimers()` patches global `Date.now` / `setTimeout` / `setInterval` / `queueMicrotask`. `runAll()` *can* throw (bounded at 10,000 iterations to catch runaway intervals), and that throw escapes before `restore()` would run. The `afterEach` guard catches all of these cases.

--- a/docs/ai/decision-tree.md
+++ b/docs/ai/decision-tree.md
@@ -1,0 +1,181 @@
+# Decision tree
+
+Which API to reach for, by task. Tables, not prose. If your question isn't answered below, it's either not a common task or you need the full [Guide](/guide/introduction).
+
+## "I want to mock X" → which factory?
+
+| What you have | Factory | Example |
+|---------------|---------|---------|
+| A TypeScript interface or type, no instance | `stub<T>(['method1', 'method2'])` | `stub<Database>(['query'])` |
+| An existing object instance | `stub(obj)` | `stub(new Logger())` |
+| A class (want prototype methods auto-discovered) | `stub(MyClass)` | `stub(Greeter)` |
+| A class (want static methods instead) | `stub(MyClass, undefined, { debug:{prefix:'deride',suffix:'stub'}, static:true })` | `stub(Greeter, undefined, {…, static:true})` |
+| Code that does `new MyClass(...)` somewhere and you want to intercept | `stub.class(MyClass)` | `stub.class(Database)` |
+| An existing object where **real methods should run by default** | `wrap(obj)` | `wrap(realLogger)` |
+| An existing standalone function | `wrap(fn)` or `func(fn)` (identical) | `wrap(handler)` |
+| A brand-new standalone function from scratch | `func<F>()` | `func<(x: number) => number>()` |
+
+**Rules of thumb:**
+- `stub` replaces, `wrap` preserves real behaviour until overridden.
+- `stub.class` is only for `new`-call interception. If you control the call site, inject a `stub(...)` instance instead.
+- Use `func()` when the dependency is **itself** a function (callback, handler, fetcher).
+
+## "I want the method to return X" → which setup?
+
+| Behaviour | Setup |
+|-----------|-------|
+| Return a fixed value | `.toReturn(value)` |
+| Return the mock itself (fluent APIs) | `.toReturnSelf()` |
+| Run custom logic with access to args | `.toDoThis((a, b) => …)` |
+| Throw an Error(msg) | `.toThrow(message)` |
+| Return a resolved Promise with a value | `.toResolveWith(value)` |
+| Return a resolved Promise with no value | `.toResolve()` |
+| Return a rejected Promise | `.toRejectWith(error)` |
+| Resolve after N ms (use with fake timers) | `.toResolveAfter(ms, value)` |
+| Reject after N ms | `.toRejectAfter(ms, error)` |
+| Return a Promise that never settles | `.toHang()` |
+| Return each value in a sequence (sticky-last) | `.toReturnInOrder(a, b, c)` |
+| Same for promises | `.toResolveInOrder(…)` / `.toRejectInOrder(…)` |
+| Return a fresh sync iterator | `.toYield(1, 2, 3)` |
+| Return a fresh async iterator | `.toAsyncYield(1, 2, 3)` |
+| Async iterator that throws partway | `.toAsyncYieldThrow(err, v1, v2)` |
+| Invoke the last callback argument | `.toCallbackWith(err, data)` |
+| Emit an event on the wrapped object | `.toEmit(eventName, …args)` |
+| Run a side-effect then run the real method | `.toIntercept((…args) => { … })` |
+| Accelerate a callback-based timeout | `.toTimeWarp(ms)` |
+| Clear all configured behaviours | `.fallback()` |
+
+## "I want to gate a behaviour" → which modifier?
+
+| Condition | Modifier (chain BEFORE the behaviour) |
+|-----------|---------------------------------------|
+| Only when first arg equals X | `.when(X)` |
+| Only when first arg passes matcher | `.when(match.string)` |
+| Only when multiple positional args match | `.when(match.string, match.number)` |
+| Only when custom predicate on args returns true | `.when((args) => …)` |
+| Only the next call | `.once()` |
+| Only the next 2 calls | `.twice()` |
+| Only the next N calls | `.times(n)` |
+
+Chain multiple behaviours in sequence:
+
+```typescript
+mock.setup.greet
+  .when('alice').toReturn('hi alice')
+  .once()
+  .and.then
+  .toReturn('default')
+```
+
+## "I want to match an argument" → which matcher?
+
+Import from `deride`: `import { match } from 'deride'`
+
+| Assertion | Matcher |
+|-----------|---------|
+| Any value, including nullish | `match.any` |
+| Not undefined (null OK) | `match.defined` |
+| Exactly null or undefined | `match.nullish` |
+| typeof string / number / boolean / bigint / symbol / function | `match.string` / `match.number` / etc. |
+| Is an array | `match.array` |
+| Is a plain object (non-null, non-array) | `match.object` |
+| `instanceof` some class | `match.instanceOf(Ctor)` |
+| Object containing these keys with these values (matcher-aware) | `match.objectContaining({ id: match.number })` |
+| Array containing these items (any order) | `match.arrayContaining([1, 2])` |
+| Strict deep equal, no extra keys | `match.exact(value)` |
+| Number / bigint > < >= <= | `match.gt(n)` / `match.gte(n)` / `match.lt(n)` / `match.lte(n)` |
+| Number / bigint in range, inclusive | `match.between(low, high)` |
+| String matches regex | `match.regex(/pattern/)` |
+| String starts/ends/includes | `match.startsWith(s)` / `match.endsWith(s)` / `match.includes(s)` |
+| NOT matching m | `match.not(m)` |
+| ALL of (m1, m2, …) | `match.allOf(m1, m2)` |
+| AT LEAST ONE of matcher list | `match.oneOf(m1, m2)` |
+| Equal to OR matches any of these values | `match.anyOf(v1, v2, …)` |
+| Custom predicate, named | `match.where(v => …, 'description')` |
+
+Matchers compose and nest — use them inside `objectContaining`, `arrayContaining`, `exact`, or anywhere a value goes.
+
+## "I want to assert how it was called" → which expect?
+
+| Question | Assertion |
+|----------|-----------|
+| Was it called exactly N times? | `.called.times(n)` / `.once()` / `.twice()` / `.never()` |
+| Call count < / <= / > / >= N | `.called.lt(n)` / `.lte(n)` / `.gt(n)` / `.gte(n)` |
+| Any call had this arg (partial deep match) | `.called.withArg(arg)` |
+| Any call had these args (all present) | `.called.withArgs(a, b)` |
+| Any call's args matched a regex (deep) | `.called.withMatch(/regex/)` |
+| Any call had EXACTLY these args (strict deep equal) | `.called.matchExactly(a, b)` |
+| Any call returned this value (or matcher) | `.called.withReturn(value)` |
+| Any call was made on this `this` | `.called.calledOn(target)` |
+| Any call threw (optional: Error message / class / matcher) | `.called.threw(expected?)` |
+| The i-th call included this arg | `.invocation(i).withArg(arg)` |
+| EVERY call matched (each of the above) | `.everyCall.withArg(…)` etc. |
+| Negate any of the above | `.called.not.withArg(...)` |
+
+**Decision rule:** if you want a test to fail when the assertion fails, use `expect.called.*`. If you want a boolean / data / to branch, use `spy.*`.
+
+## "I want to read call history" → spy surface
+
+| Need | Reach for |
+|------|-----------|
+| "Was it called with X?" as a boolean | `mock.spy.method.calledWith(x)` |
+| Total call count | `mock.spy.method.callCount` |
+| All recorded calls | `mock.spy.method.calls` |
+| First / last recorded call | `mock.spy.method.firstCall` / `lastCall` |
+| A captured return value | `mock.spy.method.lastCall?.returned` |
+| A captured `this` binding | `mock.spy.method.lastCall?.thisArg` |
+| A captured sync throw | `mock.spy.method.lastCall?.threw` |
+| Pretty-print the full call log for debugging | `mock.spy.method.printHistory()` |
+| Stable snapshot-friendly dump | `mock.spy.method.serialize()` |
+
+For async return values, `lastCall.returned` is the Promise. `await` it to get the settled value.
+
+## "I need to assert cross-mock ordering" → inOrder
+
+| Need | Reach for |
+|------|-----------|
+| Assert spies fired in this order (first call of each) | `inOrder(a.spy.x, b.spy.y, c.spy.z)` |
+| Order a specific invocation of a spy | `inOrder(inOrder.at(a.spy.x, 0), b.spy.y)` |
+| Strict: no extra calls on listed spies between | `inOrder.strict(a.spy.x, b.spy.y)` |
+
+## "I need test lifecycle helpers" → sandbox / snapshot
+
+| Need | Reach for |
+|------|-----------|
+| Reset call history on every mock between tests | `sandbox().reset()` in `afterEach` |
+| Full wipe (history + behaviours) | `sandbox().restore()` in `afterAll` |
+| Save/restore a single mock's state mid-test | `mock.snapshot()` / `mock.restore(snap)` |
+| Reset ONE mock's history | `mock.called.reset()` |
+
+## "I need fake timers" → deride/clock
+
+```typescript
+import { useFakeTimers, isFakeTimersActive, restoreActiveClock } from 'deride/clock'
+```
+
+| Need | Reach for |
+|------|-----------|
+| Install fake Date / setTimeout / setInterval / queueMicrotask | `const clock = useFakeTimers()` |
+| Advance time by N ms and fire due timers | `clock.tick(ms)` |
+| Drain all pending timers | `clock.runAll()` (throws if setInterval would loop) |
+| Drain microtasks | `clock.flushMicrotasks()` |
+| Read captured callback errors | `clock.errors` |
+| Restore native globals | `clock.restore()` |
+| Safety net in `afterEach` | `if (isFakeTimersActive()) restoreActiveClock()` |
+
+## "I need framework matchers" → deride/vitest or deride/jest
+
+```typescript
+import 'deride/vitest'   // or 'deride/jest' — side-effect import, registers matchers
+```
+
+| Matcher | Semantics |
+|---------|-----------|
+| `expect(mock.spy.x).toHaveBeenCalled()` | >= 1 call |
+| `.toHaveBeenCalledTimes(n)` | exactly N |
+| `.toHaveBeenCalledOnce()` | exactly 1 |
+| `.toHaveBeenCalledWith(...args)` | any call's args match |
+| `.toHaveBeenLastCalledWith(...args)` | last call's args match |
+| `.toHaveBeenNthCalledWith(n, ...args)` | n is **1-indexed** |
+
+Works on a `MethodSpy` (`mock.spy.greet`) or a `MockedFunction` proxy directly.

--- a/docs/ai/feeds.md
+++ b/docs/ai/feeds.md
@@ -1,0 +1,106 @@
+# Agent-ready feeds
+
+All documentation is published in three machine-friendly forms in addition to the regular HTML site. Use these when configuring an AI agent / IDE extension / MCP server / RAG pipeline.
+
+## `/llms.txt`
+
+A short, llmstxt.org-format index of every documentation page. About 3 KB. Fits trivially in any context window. Each entry has a one-line summary and a link to the `.md` variant.
+
+**URL:** <https://guzzlerio.github.io/deride/llms.txt>
+
+```text
+# deride
+
+> TypeScript-first mocking library that wraps rather than monkey-patches.
+
+## Guide
+- [Introduction](https://guzzlerio.github.io/deride/guide/introduction.md): …
+- [Quick Start](https://guzzlerio.github.io/deride/guide/quick-start.md): …
+
+## For Agents
+- [Overview](https://guzzlerio.github.io/deride/ai/index.md): …
+…
+```
+
+## `/llms-full.txt`
+
+Every page concatenated, frontmatter stripped, with visible section separators. Around 80 KB at the time of writing — well within any modern long-context window. Give this to the agent once and it has the entire docs in memory.
+
+**URL:** <https://guzzlerio.github.io/deride/llms-full.txt>
+
+## Per-page `.md` variants
+
+Every documentation page is also served as plain Markdown at the same URL with `.md` appended. No HTML parsing needed.
+
+**Examples:**
+
+- <https://guzzlerio.github.io/deride/guide/quick-start.md>
+- <https://guzzlerio.github.io/deride/ai/decision-tree.md>
+- <https://guzzlerio.github.io/deride/api/stub.md>
+- <https://guzzlerio.github.io/deride/integrations/vitest.md>
+
+## How to wire it up
+
+### Claude Code / Claude Desktop
+
+Point Claude at the docs via a [custom system prompt](https://docs.claude.com/en/docs/claude-code) or a fetched context block:
+
+```
+Before writing tests that use deride, fetch
+https://guzzlerio.github.io/deride/llms-full.txt
+and apply its patterns. Prefer the canonical examples at
+https://guzzlerio.github.io/deride/ai/canonical-examples.md
+and avoid the anti-patterns at
+https://guzzlerio.github.io/deride/ai/common-mistakes.md
+```
+
+### Cursor
+
+Add an entry to `.cursor/rules/deride.mdc` in your project:
+
+````markdown
+---
+description: Use deride for mocking in tests
+globs: **/*.test.ts, **/*.test.tsx, **/*.spec.ts
+---
+
+When writing tests that use deride, follow the patterns at
+https://guzzlerio.github.io/deride/ai/canonical-examples.md
+and avoid the anti-patterns at
+https://guzzlerio.github.io/deride/ai/common-mistakes.md
+
+Decision tree for which API to reach for:
+https://guzzlerio.github.io/deride/ai/decision-tree.md
+````
+
+### OpenAI / GPT Custom Instructions
+
+Add to your Custom Instructions:
+
+```
+When writing TypeScript test code, if deride is available
+(check package.json for the "deride" dependency), follow
+https://guzzlerio.github.io/deride/llms.txt
+```
+
+### MCP servers
+
+If you're running an MCP docs server (e.g. [docs MCP servers](https://github.com/modelcontextprotocol/servers)), `llms.txt` can be used as the index and the `.md` variants as the crawlable content.
+
+### RAG pipelines
+
+For embedding-based retrieval, the `.md` variants are ideal input — no HTML to strip, no navigation chrome, no JS-rendered content. Crawl the sitemap (`/sitemap.xml`) and fetch each URL with a `.md` suffix.
+
+## How these feeds are maintained
+
+A VitePress `buildEnd` hook in [`docs/.vitepress/emit-llm-assets.ts`](https://github.com/guzzlerio/deride/blob/develop/docs/.vitepress/emit-llm-assets.ts) walks the source markdown, strips frontmatter, and writes:
+
+- `dist/<page>.md` — a clean Markdown copy of every page
+- `dist/llms.txt` — the llmstxt.org index
+- `dist/llms-full.txt` — everything concatenated
+
+The hook runs on every `pnpm docs:build` and every GitHub Pages deploy via `.github/workflows/docs.yml`. Adding a new page under `docs/` picks up automatically — no extra build config required.
+
+## Staying current
+
+When deride's source API changes, the [Decision tree](/ai/decision-tree), [Canonical examples](/ai/canonical-examples), and [Common mistakes](/ai/common-mistakes) pages must be updated alongside the main guide. The repo's `CLAUDE.md` lists this as a project rule; CI doesn't enforce it, so drift is possible. If you notice the agent-facing pages have fallen out of sync with the primary docs, open an issue or PR.

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -1,0 +1,64 @@
+# For Agents
+
+**Context-dense docs for Claude, Cursor, Copilot, and other AI assistants writing code against deride.** Everything under `/ai/` is written for machine consumption first — terse, scannable, example-led — while still being useful to humans.
+
+If you're a human reader looking for the full guide, head to [**Introduction**](/guide/introduction). If you're an agent or an agent-assisted developer, start here.
+
+## What's in this section
+
+| Page | Purpose |
+|------|---------|
+| [Decision tree](/ai/decision-tree) | "Which factory / setup / expect do I use?" — flat tables, no prose. |
+| [Canonical examples](/ai/canonical-examples) | ONE blessed snippet per common task. Use these verbatim; they're the idiomatic shape. |
+| [Common mistakes](/ai/common-mistakes) | Anti-patterns and their fixes, phrased the way an agent is likely to produce them. |
+| [Agent-ready feeds](/ai/feeds) | `llms.txt`, `llms-full.txt`, per-page `.md` variants — the feeds you should point your agent at. |
+
+## Quick agent primer
+
+deride is a **TypeScript-first mocking library**. It wraps rather than monkey-patches, so it works with frozen objects, sealed classes, and any coding style.
+
+Three factories:
+
+```typescript
+import { stub, wrap, func } from 'deride'
+
+stub<Interface>(['methods'])   // build from method names
+stub(existingInstance)         // mirror an instance's methods
+stub(MyClass)                  // walk a class prototype
+wrap(realObject)               // partial mock — real methods run by default
+func<F>()                      // standalone mocked function
+```
+
+Three facades on every mock:
+
+```typescript
+mock.setup.method.toReturn(...)         // configure behaviour
+mock.expect.method.called.once()        // assert (throws)
+mock.spy.method.lastCall.returned       // inspect (reads data)
+```
+
+The full flavour — matchers, sandbox, inOrder, sub-paths — is in the [Guide](/guide/introduction). This section is the lean reference.
+
+## Pointing your agent at these docs
+
+Three options, from least to most context-hungry:
+
+1. **Give the agent `/llms.txt`** — a short index of every page with one-line summaries and links to the `.md` variants. ~3 KB, fits in any context window.
+2. **Give the agent `/llms-full.txt`** — every page's markdown concatenated. ~80 KB at the time of writing. Fits in any modern long-context window (Claude, GPT-4.1, Gemini 2.5, etc.).
+3. **Let the agent fetch individual `.md` variants** by appending `.md` to any URL it encounters. e.g. [`/guide/quick-start.md`](/guide/quick-start.md), [`/ai/decision-tree.md`](/ai/decision-tree.md).
+
+Full feed URLs and example MCP / tool configurations live on [Agent-ready feeds](/ai/feeds).
+
+## Design principles for this section
+
+1. **One idiomatic shape per task.** No "here are three ways…" — we pick one and document it. Agents generate from the patterns they see.
+2. **Tables over prose.** Agents don't need prose to understand a rule; they need the rule.
+3. **Negative examples alongside positive.** "Don't do X" is more useful than "do Y" alone because it steers generation away from common failure modes.
+4. **No hidden context.** Everything referenced in an example is self-contained or linked.
+5. **Conventional-commit language.** This reinforces the conventions used elsewhere in the project — useful because the agent will often be writing the commit message too.
+
+## Contributing
+
+If you're updating the main Guide or API reference, **also update the matching page here** when it changes a common pattern or introduces a new one. See the [Decision tree](/ai/decision-tree) as the first thing to sync.
+
+The `CLAUDE.md` at the repo root tells automated contributors (and Claude sessions) to keep this section current; human contributors should check `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

Gives AI coding assistants (Claude, Cursor, Copilot, MCP docs servers, anything else that ingests docs) **everything they need to write correct deride code**:

1. **\`/llms.txt\`** — llmstxt.org-format short index of every page. ~8 KB. Agents load this as a lightweight navigation map.
2. **\`/llms-full.txt\`** — every page concatenated, frontmatter stripped. ~188 KB. Agents load this once and have the entire docs in context.
3. **Per-page \`.md\` variants** — append \`.md\` to any URL to get the raw Markdown. Anthropic, Vercel, and others do this; it's becoming the de-facto pattern.
4. **New \"For Agents\" section** in the docs nav, with 5 purpose-built pages.

## The For Agents section

| Page | Role |
|------|------|
| **Overview** (\`/ai/\`) | What this section is, how to point your agent here |
| **Decision tree** (\`/ai/decision-tree\`) | \"Which API for which task?\" Every factory / setup / matcher / expectation / spy / lifecycle helper in scannable tables. No prose. |
| **Canonical examples** (\`/ai/canonical-examples\`) | 13 blessed idiomatic snippets — the designed shape for each common task. Use verbatim. |
| **Common mistakes** (\`/ai/common-mistakes\`) | 12 anti-patterns agents produce + fixes. Wrong-then-right-then-why. |
| **Agent-ready feeds** (\`/ai/feeds\`) | URLs + wiring-up snippets for Claude Code, Cursor, GPT Custom Instructions, MCP, RAG |

## Infrastructure

- **\`docs/.vitepress/emit-llm-assets.ts\`** — a VitePress \`buildEnd\` hook. Walks \`docs/\` for \`.md\` files, strips frontmatter, and emits the three artefacts listed above into \`dist/\`. ~180 lines, zero runtime deps.
- Nav gets a \"For Agents\" entry. Sidebar config includes \`/ai/\`.
- Build output on every \`pnpm docs:build\`:

  \`\`\`
  [llm-assets] wrote 36 .md variants, llms.txt (8.4 KB), llms-full.txt (188.4 KB)
  \`\`\`

- Adding a new page under \`docs/\` is picked up automatically — no extra config.

## CLAUDE.md updates

- New **\"For Agents docs section — keep this current\"** block with a table mapping guide changes to the \`docs/ai/\` page(s) that must be synced.
- Notes on the feed infrastructure and how to confirm it's still working.
- Published feed URLs for quick reference.

The deal: AI-authored PRs that change an API but leave \`docs/ai/\` stale should be caught in review. No CI enforcement today — could add a grep-based lint that warns if a new public export isn't mentioned in the decision tree.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 387 tests pass (no runtime change)
- [x] \`pnpm docs:build\` succeeds and log shows the feed emission line
- [x] Manually verified llms.txt groups pages correctly (Guide / For Agents / Integrations / API reference / Recipes)
- [x] Manually verified \`.md\` variants include \`/ai/index.md\` at the right URL (fixed one bug during development — the index-file URL was coming out as \`/ai/.md\`, corrected)
- [ ] After merge to develop: Docs workflow rebuilds, live URLs resolve — will verify

## Live URLs after merge

- https://guzzlerio.github.io/deride/llms.txt
- https://guzzlerio.github.io/deride/llms-full.txt
- https://guzzlerio.github.io/deride/ai/
- https://guzzlerio.github.io/deride/guide/quick-start.md *(any page + .md)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)