### PR TITLE
feat: fluent chaining for expect assertions with type-safe guard rails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ The 148 pre-existing v2.0 tests must continue to pass unchanged through any futu
 
 Every public declaration in `src/**.ts` must have a JSDoc comment — enforced by `jsdoc/require-jsdoc`. This covers exported functions, classes, interfaces, type aliases, `const`/`let`, and interface method signatures. Fix the doc, don't disable the rule.
 
+**When any public API signature or its JSDoc changes, always rebuild the docs** (`pnpm docs:build`) before considering the task done. This catches broken links and ensures the VitePress site and emitted feeds (`llms.txt`, `.md` variants) stay in sync.
+
 ## GitHub Pages / docs deployment
 
 `.github/workflows/docs.yml` builds the VitePress site on push to `develop` and deploys to `/next/` on the `gh-pages` branch via `peaceiris/actions-gh-pages@v4`. Release docs (`/latest/` and `/v{major}/`) are deployed by `.github/workflows/release.yml` after a successful npm publish. **Pages source must be set to "Deploy from a branch" (`gh-pages`)** in Settings → Pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ The runtime engine is a single `MethodMock` class in `src/method-mock.ts`, split
 
 The 148 pre-existing v2.0 tests must continue to pass unchanged through any future refactor. When the internal `callArgs: unknown[][]` was refactored to `calls: CallRecord[]` in v2.1, a back-compat getter was added so old assertion code still worked. Follow the same pattern if you change internals.
 
+**Before planning any work that touches public API:** if the task would remove, rename, or relocate any public API surface (methods, properties, types, exports), explicitly ask whether a breaking change is acceptable or whether backward compatibility must be preserved. Do this during planning, before implementation begins. Default assumption: backward compat is required.
+
 ## TSDoc on public exports
 
 Every public declaration in `src/**.ts` must have a JSDoc comment — enforced by `jsdoc/require-jsdoc`. This covers exported functions, classes, interfaces, type aliases, `const`/`let`, and interface method signatures. Fix the doc, don't disable the rule.

--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ bob.expect.greet.invocation(1).withArgs('second', 'extra')
 ```
 
 <a name="called-not"></a>
+<a name="not-called"></a>
 
 ### `not.called.*`
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Every-call / invocation / negation:
 
 - [`expect.method.everyCall.*`](#every-call)
 - [`expect.method.invocation(i).withArg(arg)`](#invocation)
-- [`expect.method.called.not.*`](#called-not) — negated versions
+- [`expect.method.not.called.*`](#called-not) — negated versions
 - [`expect.method.called.reset()`](#called-reset)
 - [`obj.called.reset()`](#called-reset-all) — reset all methods
 
@@ -798,16 +798,22 @@ bob.expect.greet.invocation(1).withArgs('second', 'extra')
 
 <a name="called-not"></a>
 
-### `called.not.*`
+### `not.called.*`
 
-Every positive assertion has a negated form:
+Every positive assertion has a negated form. Negation lives at the `expect.method.not` level:
 
 ```typescript
 bob.greet('alice')
-bob.expect.greet.called.not.never()
-bob.expect.greet.called.not.withArg('bob')
-bob.expect.greet.called.not.withReturn('goodbye')
-bob.expect.greet.called.not.threw()
+bob.expect.greet.not.called.never()
+bob.expect.greet.not.called.withArg('bob')
+bob.expect.greet.not.called.withReturn('goodbye')
+bob.expect.greet.not.called.threw()
+```
+
+Chaining works on negated assertions too:
+
+```typescript
+bob.expect.greet.not.called.once().withArg('nobody')
 ```
 
 <a name="called-reset"></a>

--- a/docs/next/ai/canonical-examples.md
+++ b/docs/next/ai/canonical-examples.md
@@ -29,8 +29,7 @@ describe('UserService', () => {
     const users = await service.listActive()
 
     expect(users).toHaveLength(1)
-    mockDb.expect.query.called.once()
-    mockDb.expect.query.called.withArg(match.regex(/active/i))
+    mockDb.expect.query.called.once().withArg(match.regex(/active/i))
   })
 })
 ```

--- a/docs/next/ai/common-mistakes.md
+++ b/docs/next/ai/common-mistakes.md
@@ -295,7 +295,7 @@ it('does timing stuff', () => {
 
 **Why:** `useFakeTimers()` patches global `Date.now` / `setTimeout` / `setInterval` / `queueMicrotask`. `runAll()` *can* throw (bounded at 10,000 iterations to catch runaway intervals), and that throw escapes before `restore()` would run. The `afterEach` guard catches all of these cases.
 
-## 11. Using `called.not` instead of `not.called`
+## 13. Using `called.not` instead of `not.called`
 
 **❌ Wrong**
 
@@ -309,4 +309,22 @@ mock.expect.greet.called.not.withArg('bob')
 mock.expect.greet.not.called.withArg('bob')
 ```
 
-**Why:** Negation lives at the `expect.method.not` level, not on `called`. The `.not` property is on `MockExpect`, providing negated `called` and `everyCall` branches. This also enables fluent chaining: `mock.expect.greet.not.called.once().withArg('nobody')`.
+**Why:** `called.not` is deprecated (planned removal in v3). Negation lives at the `expect.method.not` level. The `.not` property is on `MockExpect`, providing the negated `called` branch.
+
+## 14. Chaining after a negated count method
+
+**❌ Wrong**
+
+```typescript
+mock.expect.greet.not.called.once().withArg('alice')
+// Compile error — negated count methods return void
+```
+
+**✅ Right**
+
+```typescript
+mock.expect.greet.not.called.once()          // count check alone
+mock.expect.greet.called.withArg('alice')    // separate arg check
+```
+
+**Why:** Negated count methods (`once()`, `twice()`, `times()`, `lt()`, `gt()`, etc.) are terminal — they return `void`. If chaining were allowed, each link would be negated independently (De Morgan), producing surprising results: `not.once()` passes but `not.withArg('alice')` fails even though the user intended "was not called exactly once with alice". Use two separate assertions instead.

--- a/docs/next/ai/common-mistakes.md
+++ b/docs/next/ai/common-mistakes.md
@@ -294,3 +294,19 @@ it('does timing stuff', () => {
 ```
 
 **Why:** `useFakeTimers()` patches global `Date.now` / `setTimeout` / `setInterval` / `queueMicrotask`. `runAll()` *can* throw (bounded at 10,000 iterations to catch runaway intervals), and that throw escapes before `restore()` would run. The `afterEach` guard catches all of these cases.
+
+## 11. Using `called.not` instead of `not.called`
+
+**❌ Wrong**
+
+```typescript
+mock.expect.greet.called.not.withArg('bob')
+```
+
+**✅ Right**
+
+```typescript
+mock.expect.greet.not.called.withArg('bob')
+```
+
+**Why:** Negation lives at the `expect.method.not` level, not on `called`. The `.not` property is on `MockExpect`, providing negated `called` and `everyCall` branches. This also enables fluent chaining: `mock.expect.greet.not.called.once().withArg('nobody')`.

--- a/docs/next/ai/decision-tree.md
+++ b/docs/next/ai/decision-tree.md
@@ -110,7 +110,7 @@ Matchers compose and nest — use them inside `objectContaining`, `arrayContaini
 | Any call threw (optional: Error message / class / matcher) | `.called.threw(expected?)` |
 | The i-th call included this arg | `.invocation(i).withArg(arg)` |
 | EVERY call matched (each of the above) | `.everyCall.withArg(…)` etc. |
-| Negate any of the above | `.not.called.withArg(...)` |
+| Negate any of the above | `.not.called.withArg(...)` — negated count methods (`once`, `twice`, `times`, `lt`, `gt`, etc.) are **terminal** (return void, no chaining) |
 
 **Decision rule:** if you want a test to fail when the assertion fails, use `expect.called.*`. If you want a boolean / data / to branch, use `spy.*`.
 

--- a/docs/next/ai/decision-tree.md
+++ b/docs/next/ai/decision-tree.md
@@ -110,7 +110,7 @@ Matchers compose and nest — use them inside `objectContaining`, `arrayContaini
 | Any call threw (optional: Error message / class / matcher) | `.called.threw(expected?)` |
 | The i-th call included this arg | `.invocation(i).withArg(arg)` |
 | EVERY call matched (each of the above) | `.everyCall.withArg(…)` etc. |
-| Negate any of the above | `.called.not.withArg(...)` |
+| Negate any of the above | `.not.called.withArg(...)` |
 
 **Decision rule:** if you want a test to fail when the assertion fails, use `expect.called.*`. If you want a boolean / data / to branch, use `spy.*`.
 

--- a/docs/next/api/index.md
+++ b/docs/next/api/index.md
@@ -44,7 +44,9 @@ Full index in [Types](./types).
 import type {
   Wrapped,                              // result of stub()/wrap()
   TypedMockSetup, MockSetup,            // setup surface
-  MockExpect, CalledExpect, InvocationExpect,  // expect surface
+  MockExpect, ExpectBranches, CalledExpect,     // expect surface
+  EveryCallExpect, CountAssertions,
+  ArgAssertions, InvocationExpect,
   MethodSpy, CallRecord,                // spy surface
   MockSnapshot, Sandbox,                // lifecycle
   MockedFunction, MockedClass,          // callable mocks / class mocks

--- a/docs/next/api/types.md
+++ b/docs/next/api/types.md
@@ -100,9 +100,22 @@ interface CountAssertions {
   gte(n: number): ArgAssertions
 }
 
+// Count methods that return void (terminal) — used on the negated branch
+interface TerminalCountAssertions {
+  times(n: number, err?: string): void
+  once(): void
+  twice(): void
+  lt(n: number): void
+  lte(n: number): void
+  gt(n: number): void
+  gte(n: number): void
+}
+
 interface CalledExpect extends CountAssertions, ArgAssertions {
   never(): void
   reset(): void
+  /** @deprecated Use `expect.method.not.called.*` instead. Planned removal in v3. */
+  not: TerminalCountAssertions & ArgAssertions
 }
 
 interface EveryCallExpect extends CountAssertions, ArgAssertions {}
@@ -114,7 +127,9 @@ interface ExpectBranches {
 
 interface MockExpect extends ExpectBranches {
   invocation(index: number): InvocationExpect
-  not: ExpectBranches
+  not: {
+    called: TerminalCountAssertions & ArgAssertions
+  }
 }
 
 interface InvocationExpect {

--- a/docs/next/api/types.md
+++ b/docs/next/api/types.md
@@ -80,34 +80,41 @@ type MockSetup = TypedMockSetup<any[], any>
 ## Expect — `MockExpect`
 
 ```typescript
-interface MockExpect {
-  called: CalledExpect
-  everyCall: Omit<CalledExpect, 'reset' | 'not'>
-  invocation(index: number): InvocationExpect
+interface ArgAssertions {
+  withArg(arg: unknown): ArgAssertions
+  withArgs(...args: unknown[]): ArgAssertions
+  withMatch(pattern: RegExp): ArgAssertions
+  matchExactly(...args: unknown[]): ArgAssertions
+  withReturn(expected: unknown): ArgAssertions
+  calledOn(target: unknown): ArgAssertions
+  threw(expected?: unknown): ArgAssertions
 }
 
-interface CalledExpect {
-  times(n: number, err?: string): void
-  once(): void
-  twice(): void
+interface CountAssertions {
+  times(n: number, err?: string): ArgAssertions
+  once(): ArgAssertions
+  twice(): ArgAssertions
+  lt(n: number): ArgAssertions
+  lte(n: number): ArgAssertions
+  gt(n: number): ArgAssertions
+  gte(n: number): ArgAssertions
+}
+
+interface CalledExpect extends CountAssertions, ArgAssertions {
   never(): void
-
-  lt(n: number): void
-  lte(n: number): void
-  gt(n: number): void
-  gte(n: number): void
-
-  withArg(arg: unknown): void
-  withArgs(...args: unknown[]): void
-  withMatch(pattern: RegExp): void
-  matchExactly(...args: unknown[]): void
-
-  withReturn(expected: unknown): void
-  calledOn(target: unknown): void
-  threw(expected?: unknown): void
-
   reset(): void
-  not: Omit<CalledExpect, 'reset' | 'not'>
+}
+
+interface EveryCallExpect extends CountAssertions, ArgAssertions {}
+
+interface ExpectBranches {
+  called: CalledExpect
+  everyCall: EveryCallExpect
+}
+
+interface MockExpect extends ExpectBranches {
+  invocation(index: number): InvocationExpect
+  not: ExpectBranches
 }
 
 interface InvocationExpect {

--- a/docs/next/guide/expectations.md
+++ b/docs/next/guide/expectations.md
@@ -169,21 +169,55 @@ mock.expect.greet.invocation(1).withArg('nope')
 // throws: invocation out of range
 ```
 
+## Fluent chaining
+
+Assertions can be chained fluently. Count assertions (`once`, `twice`, `times`, `lt`, `gt`, etc.) return an arg-assertion object, so you can follow a count check with argument or return checks:
+
+```typescript
+mock.greet('alice')
+mock.expect.greet.called.once().withArg('alice')
+mock.expect.greet.called.once().withReturn('hi')
+```
+
+Arg assertions chain with each other:
+
+```typescript
+mock.expect.greet.called.withArg('alice').withReturn('hi')
+```
+
+The type system prevents invalid chains — you cannot follow a count with another count:
+
+```typescript
+mock.expect.greet.called.once().twice()  // compile error
+```
+
+`never()` is terminal and returns `void` — nothing can follow it:
+
+```typescript
+mock.expect.greet.called.never()         // no chaining
+```
+
 ## Negation — `.not.*`
 
-Every positive `called.*` assertion has a `.not` counterpart. It passes when the positive would have thrown:
+Every positive `called.*` / `everyCall.*` assertion has a `.not` counterpart at the `expect.method.not` level. It passes when the positive would have thrown:
 
 ```typescript
 mock.greet('alice')
 
-mock.expect.greet.called.not.never()         // it WAS called
-mock.expect.greet.called.not.twice()         // it was called once, not twice
-mock.expect.greet.called.not.withArg('bob')  // 'bob' was never passed
-mock.expect.greet.called.not.withReturn('goodbye')
-mock.expect.greet.called.not.threw()
+mock.expect.greet.not.called.never()              // it WAS called
+mock.expect.greet.not.called.twice()              // it was called once, not twice
+mock.expect.greet.not.called.withArg('bob')       // 'bob' was never passed
+mock.expect.greet.not.called.withReturn('goodbye')
+mock.expect.greet.not.called.threw()
 ```
 
-`.not` is available on `called` only (not on `everyCall` or `invocation`).
+Negated assertions also support chaining:
+
+```typescript
+mock.expect.greet.not.called.once().withArg('nobody')
+```
+
+`.not` is available on both `called` and `everyCall` (not on `invocation`).
 
 ## Resetting
 

--- a/docs/next/guide/expectations.md
+++ b/docs/next/guide/expectations.md
@@ -199,7 +199,7 @@ mock.expect.greet.called.never()         // no chaining
 
 ## Negation — `.not.*`
 
-Every positive `called.*` / `everyCall.*` assertion has a `.not` counterpart at the `expect.method.not` level. It passes when the positive would have thrown:
+Every positive `called.*` assertion has a `.not` counterpart at the `expect.method.not` level. It passes when the positive would have thrown:
 
 ```typescript
 mock.greet('alice')
@@ -211,13 +211,26 @@ mock.expect.greet.not.called.withReturn('goodbye')
 mock.expect.greet.not.called.threw()
 ```
 
-Negated assertions also support chaining:
+Negated **arg** assertions chain with each other:
 
 ```typescript
-mock.expect.greet.not.called.once().withArg('nobody')
+mock.expect.greet.not.called.withArg('bob').withReturn('goodbye')
 ```
 
-`.not` is available on both `called` and `everyCall` (not on `invocation`).
+Negated **count** methods (`once()`, `twice()`, `times()`, `lt()`, `gt()`, etc.) are **terminal** — they return `void` and cannot be chained. This prevents confusing semantics where each link would be negated independently:
+
+```typescript
+// ✅ Two separate assertions — clear intent
+mock.expect.greet.not.called.once()          // was not called exactly once
+mock.expect.greet.called.withArg('alice')    // was called with alice
+
+// ❌ Compile error — negated count is terminal
+mock.expect.greet.not.called.once().withArg('alice')
+```
+
+::: warning Deprecated: `called.not`
+The older `mock.expect.greet.called.not.*` form still works at runtime but is deprecated (planned removal in v3). Prefer `mock.expect.greet.not.called.*`.
+:::
 
 ## Resetting
 

--- a/docs/next/guide/typescript.md
+++ b/docs/next/guide/typescript.md
@@ -89,7 +89,9 @@ import type {
   TypedMockSetup, MockSetup,
 
   // Expect surface
-  MockExpect, CalledExpect, InvocationExpect,
+  MockExpect, ExpectBranches, CalledExpect,
+  EveryCallExpect, CountAssertions,
+  ArgAssertions, InvocationExpect,
 
   // Spy surface
   MethodSpy, CallRecord,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deride",
   "description": "Mocking library based on composition",
   "version": "2.0.0",
-  "homepage": "https://github.com/guzzlerio/deride",
+  "homepage": "https://guzzlerio.github.io/deride/",
   "author": {
     "name": "Andrew Rea",
     "url": "http://www.andrewrea.co.uk"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,18 @@ import { wrap } from './wrap.js'
 export { func, inOrder, match, sandbox, stub, wrap }
 export type { Wrapped, Options } from './types.js'
 export type {
-  TypedMockSetup,
-  MockSetup,
-  MockExpect,
+  ArgAssertions,
   CalledExpect,
+  CallRecord,
+  CountAssertions,
+  EveryCallExpect,
+  ExpectBranches,
   InvocationExpect,
   MethodSpy,
-  CallRecord,
+  MockExpect,
+  MockSetup,
   MockSnapshot,
+  TypedMockSetup,
 } from './method-mock.js'
 export type { MockedFunction } from './func.js'
 export type { Matcher } from './matchers.js'

--- a/src/method-mock.ts
+++ b/src/method-mock.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import { CallRecord, MockSnapshot, nextSeq } from './call-record.js'
 import { createExpect, MockExpect } from './mock-expect.js'
 import { createSetup, MockSetup, StubBehavior } from './mock-setup.js'
-import { createSpy, MethodSpy } from './mock-spy.js'
+import { Spy, MethodSpy } from './mock-spy.js'
 import { cloneDeep, PREFIX } from './utils.js'
 
 type AnyFunc = (...args: any[]) => any
@@ -81,7 +81,7 @@ export class MethodMock {
 
     this.setup = createSetup(setupHost)
     this.expect = createExpect(spyExpectHost)
-    this.spy = createSpy(spyExpectHost)
+    this.spy = new Spy(spyExpectHost)
   }
 
   /** Attach the wrapped object — used by `toReturnSelf` and for `this` defaulting. */
@@ -208,7 +208,11 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 // Re-export the types the rest of the codebase (and the public API) consume.
 export type { CallRecord, MockSnapshot } from './call-record.js'
 export type {
+  ArgAssertions,
   CalledExpect,
+  CountAssertions,
+  EveryCallExpect,
+  ExpectBranches,
   InvocationExpect,
   MockExpect,
 } from './mock-expect.js'

--- a/src/mock-expect.ts
+++ b/src/mock-expect.ts
@@ -6,45 +6,76 @@ import { historySuffix } from './mock-spy.js'
 import { deepMatch, hasMatch, humanise } from './utils.js'
 
 /**
- * Assertions about how a method was called. The `.called` branch asserts
- * "at least one" call matches; the `.everyCall` sister-branch on `MockExpect`
- * asserts "all" calls match.
+ * Argument, return-value, context, and throw assertions — chainable with
+ * each other. Returned by count assertions so you can write
+ * `called.once().withArg(x)` but NOT `called.once().twice()`.
  */
-export interface CalledExpect {
-  /** Assert called exactly `n` times. */
-  times(n: number, err?: string): void
-  /** Assert called exactly once. */
-  once(): void
-  /** Assert called exactly twice. */
-  twice(): void
-  /** Assert never called. */
-  never(): void
-  /** Assert call count is less than `n`. */
-  lt(n: number): void
-  /** Assert call count is less than or equal to `n`. */
-  lte(n: number): void
-  /** Assert call count is greater than `n`. */
-  gt(n: number): void
-  /** Assert call count is greater than or equal to `n`. */
-  gte(n: number): void
+export interface ArgAssertions {
   /** Assert called with an argument matching (partial deep equal, matcher-aware). */
-  withArg(arg: unknown): void
+  withArg(arg: unknown): ArgAssertions
   /** Assert called with all specified arguments (partial deep equal, matcher-aware). */
-  withArgs(...args: unknown[]): void
+  withArgs(...args: unknown[]): ArgAssertions
   /** Assert called with an argument matching the regex pattern (searches nested strings). */
-  withMatch(pattern: RegExp): void
+  withMatch(pattern: RegExp): ArgAssertions
   /** Assert called with exactly these arguments (strict deep equal, matcher-aware). */
-  matchExactly(...args: unknown[]): void
+  matchExactly(...args: unknown[]): ArgAssertions
   /** Assert at least one call returned a value matching `expected` (value or matcher). */
-  withReturn(expected: unknown): void
+  withReturn(expected: unknown): ArgAssertions
   /** Assert at least one call had its `this` bound to `target` (identity compare). */
-  calledOn(target: unknown): void
+  calledOn(target: unknown): ArgAssertions
   /** Assert at least one call threw. With no argument, any throw passes. */
-  threw(expected?: unknown): void
-  /** Reset call count and recorded arguments. */
+  threw(expected?: unknown): ArgAssertions
+}
+
+/**
+ * Call-count assertions. Each returns `ArgAssertions` so you can chain
+ * argument/return checks after a count check, but not another count check.
+ */
+export interface CountAssertions {
+  /** Assert called exactly `n` times. */
+  times(n: number, err?: string): ArgAssertions
+  /** Assert called exactly once. */
+  once(): ArgAssertions
+  /** Assert called exactly twice. */
+  twice(): ArgAssertions
+  /** Assert call count is less than `n`. */
+  lt(n: number): ArgAssertions
+  /** Assert call count is less than or equal to `n`. */
+  lte(n: number): ArgAssertions
+  /** Assert call count is greater than `n`. */
+  gt(n: number): ArgAssertions
+  /** Assert call count is greater than or equal to `n`. */
+  gte(n: number): ArgAssertions
+}
+
+/**
+ * Full assertion surface for the `.called` branch — count + arg assertions
+ * plus terminal `never()` and `reset()`.
+ */
+export interface CalledExpect extends CountAssertions, ArgAssertions {
+  /** Assert never called. Terminal — returns void, no chaining. */
+  never(): void
+  /** Reset call count and recorded arguments. Terminal — returns void. */
   reset(): void
-  /** Negated expectations — pass when the positive assertion would fail. */
-  not: Omit<CalledExpect, 'reset' | 'not'>
+  /** @deprecated Use `expect.method.not.called.*` instead. */
+  not: CountAssertions & ArgAssertions & { never(): void }
+}
+
+/**
+ * Assertion surface for the `.everyCall` branch — count + arg assertions.
+ * Throws when the method was never called (no vacuous-true).
+ */
+export interface EveryCallExpect extends CountAssertions, ArgAssertions {}
+
+/**
+ * Shared shape for `called`/`everyCall` branches, used by both
+ * `MockExpect` and `MockExpect.not`.
+ */
+export interface ExpectBranches {
+  /** "At-least-one" assertions. */
+  called: CalledExpect
+  /** "Every-call" assertions; throws when the method was never called (no vacuous-true). */
+  everyCall: EveryCallExpect
 }
 
 /**
@@ -59,13 +90,11 @@ export interface InvocationExpect {
 }
 
 /** Expectation surface for a mocked method — the top-level `mock.expect.method`. */
-export interface MockExpect {
-  /** "At-least-one" assertions. */
-  called: CalledExpect
-  /** "Every-call" assertions; throws when the method was never called (no vacuous-true). */
-  everyCall: Omit<CalledExpect, 'reset' | 'not'>
+export interface MockExpect extends ExpectBranches {
   /** Assertions against a single invocation by zero-based index. */
   invocation(index: number): InvocationExpect
+  /** Negated expectations — pass when the positive assertion would fail. */
+  not: ExpectBranches
 }
 
 /** Narrow surface the expect factory needs from the owning MethodMock. */
@@ -93,193 +122,233 @@ function matchThrow(record: CallRecord, expected: unknown): boolean {
 }
 
 /**
- * Build the `called` / `everyCall` assertion objects, parameterised by
- * whether the quantifier is `some` or `every`. The two branches share this
- * single implementation — behaviour differs only in which array method is
- * used to aggregate per-call results.
+ * Assertion engine parameterised by quantifier (`some` or `every`).
+ * The `called` branch uses `some` (at-least-one match); the `everyCall`
+ * branch uses `every` (all calls must match).
+ *
+ * Every method returns `this` for fluent chaining, except `never()` which
+ * is terminal and returns `void`.
  */
-function buildAssertions(
-  host: ExpectHost,
-  quantifier: Quantifier
-): Omit<CalledExpect, 'reset' | 'not'> {
-  const agg = <T>(items: readonly T[], pred: (v: T) => boolean) =>
-    quantifier === 'some' ? items.some(pred) : items.every(pred)
+class AssertionBuilder implements CountAssertions, ArgAssertions {
+  private readonly isEvery: boolean
+  private readonly label: string
 
-  const label = quantifier === 'some' ? '' : 'every call of '
+  constructor(
+    private readonly host: ExpectHost,
+    quantifier: Quantifier
+  ) {
+    this.isEvery = quantifier === 'every'
+    this.label = this.isEvery ? 'every call of ' : ''
+  }
 
-  function assertCalled() {
-    if (quantifier === 'every' && host.calls.length === 0) {
-      assert.fail(`Expected ${label}${host.name} but it was never called`)
+  private aggregate(pred: (c: CallRecord) => boolean): boolean {
+    return this.isEvery
+      ? this.host.calls.every(pred)
+      : this.host.calls.some(pred)
+  }
+
+  private assertCalled(): void {
+    if (this.isEvery && this.host.calls.length === 0) {
+      assert.fail(`Expected ${this.label}${this.host.name} but it was never called`)
     }
   }
 
-  const calls = () => host.calls
+  // ── Count assertions ──────────────────────────────────────────
 
-  return {
-    times(n: number, err?: string) {
-      if (!err) {
-        err = `Expected ${host.name} to be called ${humanise(n)} but was ${humanise(host.calls.length)}`
+  times(n: number, err?: string): this {
+    if (!err) {
+      err = `Expected ${this.host.name} to be called ${humanise(n)} but was ${humanise(this.host.calls.length)}`
+    }
+    assert.equal(this.host.calls.length, n, err)
+    return this
+  }
+
+  once(): this {
+    this.times(1)
+    return this
+  }
+
+  twice(): this {
+    this.times(2)
+    return this
+  }
+
+  never(): void {
+    this.times(0, `Expected ${this.host.name} to never be called but was ${humanise(this.host.calls.length)}`)
+  }
+
+  lt(n: number): this {
+    assert(
+      this.host.calls.length < n,
+      `Expected ${this.host.name} call count < ${n}, but got ${this.host.calls.length}`
+    )
+    return this
+  }
+
+  lte(n: number): this {
+    assert(
+      this.host.calls.length <= n,
+      `Expected ${this.host.name} call count <= ${n}, but got ${this.host.calls.length}`
+    )
+    return this
+  }
+
+  gt(n: number): this {
+    assert(
+      this.host.calls.length > n,
+      `Expected ${this.host.name} call count > ${n}, but got ${this.host.calls.length}`
+    )
+    return this
+  }
+
+  gte(n: number): this {
+    assert(
+      this.host.calls.length >= n,
+      `Expected ${this.host.name} call count >= ${n}, but got ${this.host.calls.length}`
+    )
+    return this
+  }
+
+  // ── Arg / return / context assertions ─────────────────────────
+
+  withArg(arg: unknown): this {
+    this.assertCalled()
+    const result = this.aggregate((c) => hasMatch(c.args, arg))
+    assert(
+      result,
+      `Expected ${this.label}${this.host.name} to be called with: ${inspect(arg)}${historySuffix(this.host)}`
+    )
+    return this
+  }
+
+  withArgs(...args: unknown[]): this {
+    this.assertCalled()
+    const result = this.aggregate((c) =>
+      args.every((expected) => hasMatch(c.args, expected))
+    )
+    assert(
+      result,
+      `Expected ${this.label}${this.host.name} to be called with: ${args.join(', ')}${historySuffix(this.host)}`
+    )
+    return this
+  }
+
+  withMatch(pattern: RegExp): this {
+    this.assertCalled()
+    const result = this.aggregate((c) =>
+      (c.args).some((arg) =>
+        typeof arg === 'object' && arg !== null
+          ? deepMatch(arg as object, pattern)
+          : pattern.test(String(arg))
+      )
+    )
+    assert(result, `Expected ${this.label}${this.host.name} to be called matching: ${pattern}`)
+    return this
+  }
+
+  matchExactly(...expectedArgs: unknown[]): this {
+    this.assertCalled()
+    const matched = this.aggregate((c) =>
+      c.args.length === expectedArgs.length &&
+      (c.args).every((a, i) => matchValue(a, expectedArgs[i]))
+    )
+    assert(
+      matched,
+      `Expected ${this.label}${this.host.name} to be called matchExactly args${inspect(expectedArgs, { depth: 10 })}`
+    )
+    return this
+  }
+
+  withReturn(expected: unknown): this {
+    this.assertCalled()
+    const matched = this.aggregate((c) => 'returned' in c && matchValue(c.returned, expected))
+    assert(
+      matched,
+      `Expected ${this.label}${this.host.name} to have returned: ${inspect(expected)}${historySuffix(this.host)}`
+    )
+    return this
+  }
+
+  calledOn(target: unknown): this {
+    this.assertCalled()
+    assert(
+      this.aggregate((c) => c.thisArg === target),
+      `Expected ${this.label}${this.host.name} to have been called on the given target`
+    )
+    return this
+  }
+
+  threw(expected?: unknown): this {
+    this.assertCalled()
+    assert(
+      this.aggregate((c) => matchThrow(c, expected)),
+      `Expected ${this.label}${this.host.name} to have thrown${expected !== undefined ? ': ' + inspect(expected) : ''}`
+    )
+    return this
+  }
+}
+
+/**
+ * Wrap a builder in a Proxy that negates every method call — the method
+ * passes iff the original would have thrown. Chaining returns the proxy
+ * itself (except `never` which stays terminal).
+ */
+function negateBranch(source: AssertionBuilder): AssertionBuilder {
+  return new Proxy(source, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, target)
+      if (typeof value !== 'function') return value
+      return (...args: unknown[]) => {
+        try {
+          value.apply(target, args)
+        } catch {
+          return prop === 'never' ? undefined : receiver
+        }
+        assert.fail(`Expected negated assertion to fail but it passed`)
       }
-      assert.equal(host.calls.length, n, err)
     },
-    once() {
-      this.times(1)
-    },
-    twice() {
-      this.times(2)
-    },
-    never() {
-      this.times(0, `Expected ${host.name} to never be called but was ${humanise(host.calls.length)}`)
-    },
-    lt(n: number) {
-      assert(
-        host.calls.length < n,
-        `Expected ${host.name} call count < ${n}, but got ${host.calls.length}`
-      )
-    },
-    lte(n: number) {
-      assert(
-        host.calls.length <= n,
-        `Expected ${host.name} call count <= ${n}, but got ${host.calls.length}`
-      )
-    },
-    gt(n: number) {
-      assert(
-        host.calls.length > n,
-        `Expected ${host.name} call count > ${n}, but got ${host.calls.length}`
-      )
-    },
-    gte(n: number) {
-      assert(
-        host.calls.length >= n,
-        `Expected ${host.name} call count >= ${n}, but got ${host.calls.length}`
-      )
-    },
-    withArg(arg: unknown) {
-      assertCalled()
-      const result = agg(calls(), (c) => hasMatch(c.args as readonly unknown[], arg))
-      assert(
-        result,
-        `Expected ${label}${host.name} to be called with: ${inspect(arg)}${historySuffix(host)}`
-      )
-    },
-    withArgs(...args: unknown[]) {
-      assertCalled()
-      const result = agg(calls(), (c) =>
-        args.every((expected) => hasMatch(c.args as readonly unknown[], expected))
-      )
-      assert(
-        result,
-        `Expected ${label}${host.name} to be called with: ${args.join(', ')}${historySuffix(host)}`
-      )
-    },
-    withMatch(pattern: RegExp) {
-      assertCalled()
-      const matchOne = (c: CallRecord) =>
-        (c.args as unknown[]).some((arg) =>
-          typeof arg === 'object' && arg !== null
-            ? deepMatch(arg as object, pattern)
-            : pattern.test(String(arg))
-        )
-      assert(agg(calls(), matchOne), `Expected ${label}${host.name} to be called matching: ${pattern}`)
-    },
-    matchExactly(...expectedArgs: unknown[]) {
-      assertCalled()
-      const matched = agg(calls(), (c) =>
-        c.args.length === expectedArgs.length &&
-        (c.args as unknown[]).every((a, i) => matchValue(a, expectedArgs[i]))
-      )
-      assert(
-        matched,
-        `Expected ${label}${host.name} to be called matchExactly args${inspect(expectedArgs, { depth: 10 })}`
-      )
-    },
-    withReturn(expected: unknown) {
-      assertCalled()
-      const matched = agg(calls(), (c) => 'returned' in c && matchValue(c.returned, expected))
-      assert(
-        matched,
-        `Expected ${label}${host.name} to have returned: ${inspect(expected)}${historySuffix(host)}`
-      )
-    },
-    calledOn(target: unknown) {
-      assertCalled()
-      assert(
-        agg(calls(), (c) => c.thisArg === target),
-        `Expected ${label}${host.name} to have been called on the given target`
-      )
-    },
-    threw(expected?: unknown) {
-      assertCalled()
-      assert(
-        agg(calls(), (c) => matchThrow(c, expected)),
-        `Expected ${label}${host.name} to have thrown${expected !== undefined ? ': ' + inspect(expected) : ''}`
-      )
-    },
-  }
+  })
 }
 
-/** Wrap an assertion function so it passes iff the original would throw. */
-function negate<F extends (...args: any[]) => void>(fn: F): F {
-  return ((...args: unknown[]) => {
-    try {
-      ;(fn as unknown as (...a: unknown[]) => void)(...args)
-    } catch {
-      return
-    }
-    assert.fail(`Expected negated assertion to fail but it passed`)
-  }) as unknown as F
-}
-
-/** Build the full `mock.expect.method` surface (called + everyCall + invocation). */
+/** Build the full `mock.expect.method` surface (called + everyCall + not + invocation). */
 export function createExpect(host: ExpectHost): MockExpect {
-  const someBranch = buildAssertions(host, 'some')
-  const everyBranch = buildAssertions(host, 'every')
+  const someBuilder = new AssertionBuilder(host, 'some')
+  const everyBuilder = new AssertionBuilder(host, 'every')
 
-  const called: CalledExpect = {
-    ...someBranch,
-    reset() {
-      host.clearCalls()
-    },
-    not: {} as Omit<CalledExpect, 'reset' | 'not'>,
-  }
+  const negatedSome = negateBranch(someBuilder)
 
-  called.not = {
-    times: negate(called.times.bind(called)),
-    once: negate(called.once.bind(called)),
-    twice: negate(called.twice.bind(called)),
-    never: negate(called.never.bind(called)),
-    lt: negate(called.lt.bind(called)),
-    lte: negate(called.lte.bind(called)),
-    gt: negate(called.gt.bind(called)),
-    gte: negate(called.gte.bind(called)),
-    withArg: negate(called.withArg.bind(called)),
-    withArgs: negate(called.withArgs.bind(called)),
-    withMatch: negate(called.withMatch.bind(called)),
-    matchExactly: negate(called.matchExactly.bind(called)),
-    withReturn: negate(called.withReturn.bind(called)),
-    calledOn: negate(called.calledOn.bind(called)),
-    threw: negate(called.threw.bind(called)),
-  }
+  const called: CalledExpect = Object.create(someBuilder, {
+    reset: { value: () => host.clearCalls() },
+    not: { value: negatedSome },
+  })
+
+  const notCalled: CalledExpect = Object.create(negatedSome, {
+    reset: { value: () => host.clearCalls() },
+    not: { value: someBuilder },
+  })
 
   return {
     called,
-    everyCall: everyBranch,
+    everyCall: everyBuilder,
+    not: {
+      called: notCalled,
+      everyCall: negateBranch(everyBuilder),
+    },
     invocation(index: number): InvocationExpect {
       if (index >= host.calls.length) {
         throw new Error('invocation out of range')
       }
-      const args = host.calls[index].args as unknown[]
+      const record = host.calls[index]
       return {
         withArg(arg: unknown) {
           assert(
-            hasMatch(args, arg),
+            hasMatch(record.args, arg),
             `Invocation #${index} did not include argument ${inspect(arg)}`
           )
         },
         withArgs(...expectedArgs: unknown[]) {
           assert(
-            expectedArgs.every((expected) => hasMatch(args, expected)),
+            expectedArgs.every((expected) => hasMatch(record.args, expected)),
             `Invocation #${index} did not include arguments ${inspect(expectedArgs)}`
           )
         },

--- a/src/mock-expect.ts
+++ b/src/mock-expect.ts
@@ -48,6 +48,23 @@ export interface CountAssertions {
   gte(n: number): ArgAssertions
 }
 
+interface TerminalCountAssertions {
+  /** Assert called exactly `n` times. */
+  times(n: number, err?: string): void
+  /** Assert called exactly once. */
+  once(): void
+  /** Assert called exactly twice. */
+  twice(): void
+  /** Assert call count is less than `n`. */
+  lt(n: number): void
+  /** Assert call count is less than or equal to `n`. */
+  lte(n: number): void
+  /** Assert call count is greater than `n`. */
+  gt(n: number): void
+  /** Assert call count is greater than or equal to `n`. */
+  gte(n: number): void
+}
+
 /**
  * Full assertion surface for the `.called` branch — count + arg assertions
  * plus terminal `never()` and `reset()`.
@@ -57,8 +74,8 @@ export interface CalledExpect extends CountAssertions, ArgAssertions {
   never(): void
   /** Reset call count and recorded arguments. Terminal — returns void. */
   reset(): void
-  /** @deprecated Use `expect.method.not.called.*` instead. */
-  not: CountAssertions & ArgAssertions & { never(): void }
+  /** @deprecated Use `expect.method.not.called.*` instead. Planned removal in v3 */
+  not: TerminalCountAssertions & ArgAssertions
 }
 
 /**
@@ -94,7 +111,9 @@ export interface MockExpect extends ExpectBranches {
   /** Assertions against a single invocation by zero-based index. */
   invocation(index: number): InvocationExpect
   /** Negated expectations — pass when the positive assertion would fail. */
-  not: ExpectBranches
+  not: {
+    called: TerminalCountAssertions & ArgAssertions
+  }
 }
 
 /** Narrow surface the expect factory needs from the owning MethodMock. */
@@ -142,9 +161,7 @@ class AssertionBuilder implements CountAssertions, ArgAssertions {
   }
 
   private aggregate(pred: (c: CallRecord) => boolean): boolean {
-    return this.isEvery
-      ? this.host.calls.every(pred)
-      : this.host.calls.some(pred)
+    return this.isEvery ? this.host.calls.every(pred) : this.host.calls.some(pred)
   }
 
   private assertCalled(): void {
@@ -223,9 +240,7 @@ class AssertionBuilder implements CountAssertions, ArgAssertions {
 
   withArgs(...args: unknown[]): this {
     this.assertCalled()
-    const result = this.aggregate((c) =>
-      args.every((expected) => hasMatch(c.args, expected))
-    )
+    const result = this.aggregate((c) => args.every((expected) => hasMatch(c.args, expected)))
     assert(
       result,
       `Expected ${this.label}${this.host.name} to be called with: ${args.join(', ')}${historySuffix(this.host)}`
@@ -236,10 +251,8 @@ class AssertionBuilder implements CountAssertions, ArgAssertions {
   withMatch(pattern: RegExp): this {
     this.assertCalled()
     const result = this.aggregate((c) =>
-      (c.args).some((arg) =>
-        typeof arg === 'object' && arg !== null
-          ? deepMatch(arg as object, pattern)
-          : pattern.test(String(arg))
+      c.args.some((arg) =>
+        typeof arg === 'object' && arg !== null ? deepMatch(arg as object, pattern) : pattern.test(String(arg))
       )
     )
     assert(result, `Expected ${this.label}${this.host.name} to be called matching: ${pattern}`)
@@ -248,9 +261,8 @@ class AssertionBuilder implements CountAssertions, ArgAssertions {
 
   matchExactly(...expectedArgs: unknown[]): this {
     this.assertCalled()
-    const matched = this.aggregate((c) =>
-      c.args.length === expectedArgs.length &&
-      (c.args).every((a, i) => matchValue(a, expectedArgs[i]))
+    const matched = this.aggregate(
+      (c) => c.args.length === expectedArgs.length && c.args.every((a, i) => matchValue(a, expectedArgs[i]))
     )
     assert(
       matched,
@@ -288,10 +300,15 @@ class AssertionBuilder implements CountAssertions, ArgAssertions {
   }
 }
 
+/** Method names that are terminal — negated calls return void, not the proxy. */
+const TERMINAL_METHODS: ReadonlySet<string | symbol> = new Set([
+  'never', 'times', 'once', 'twice', 'lt', 'lte', 'gt', 'gte',
+])
+
 /**
  * Wrap a builder in a Proxy that negates every method call — the method
- * passes iff the original would have thrown. Chaining returns the proxy
- * itself (except `never` which stays terminal).
+ * passes iff the original would have thrown. Count methods and `never`
+ * are terminal (return void); arg methods return the proxy for chaining.
  */
 function negateBranch(source: AssertionBuilder): AssertionBuilder {
   return new Proxy(source, {
@@ -302,7 +319,7 @@ function negateBranch(source: AssertionBuilder): AssertionBuilder {
         try {
           value.apply(target, args)
         } catch {
-          return prop === 'never' ? undefined : receiver
+          return TERMINAL_METHODS.has(prop) ? undefined : receiver
         }
         assert.fail(`Expected negated assertion to fail but it passed`)
       }
@@ -317,13 +334,17 @@ export function createExpect(host: ExpectHost): MockExpect {
 
   const negatedSome = negateBranch(someBuilder)
 
+  // Prototype chain: called → someBuilder → AssertionBuilder.prototype
+  // so called.once() dispatches through someBuilder to AssertionBuilder#once.
+  // Own properties (reset, not) shadow the prototype for those keys only.
   const called: CalledExpect = Object.create(someBuilder, {
     reset: { value: () => host.clearCalls() },
     not: { value: negatedSome },
   })
 
-  const notCalled: CalledExpect = Object.create(negatedSome, {
-    reset: { value: () => host.clearCalls() },
+  // Prototype chain: notCalled → negatedSome (Proxy) → AssertionBuilder.prototype
+  // Every method call is intercepted by the Proxy and negated.
+  const notCalled: TerminalCountAssertions & ArgAssertions = Object.create(negatedSome, {
     not: { value: someBuilder },
   })
 
@@ -332,7 +353,6 @@ export function createExpect(host: ExpectHost): MockExpect {
     everyCall: everyBuilder,
     not: {
       called: notCalled,
-      everyCall: negateBranch(everyBuilder),
     },
     invocation(index: number): InvocationExpect {
       if (index >= host.calls.length) {
@@ -341,10 +361,7 @@ export function createExpect(host: ExpectHost): MockExpect {
       const record = host.calls[index]
       return {
         withArg(arg: unknown) {
-          assert(
-            hasMatch(record.args, arg),
-            `Invocation #${index} did not include argument ${inspect(arg)}`
-          )
+          assert(hasMatch(record.args, arg), `Invocation #${index} did not include argument ${inspect(arg)}`)
         },
         withArgs(...expectedArgs: unknown[]) {
           assert(

--- a/src/mock-spy.ts
+++ b/src/mock-spy.ts
@@ -50,8 +50,7 @@ export function stableSerialise(value: unknown, seen = new WeakSet<object>()): u
   if (value === null || value === undefined) return value
   if (typeof value !== 'object') {
     if (typeof value === 'function') {
-      const name = (value as { name?: string }).name
-      return `[Function${name ? ': ' + name : ''}]`
+      return `[Function${value.name ? ': ' + value.name : ''}]`
     }
     if (typeof value === 'bigint') return `${value.toString()}n`
     if (typeof value === 'symbol') return value.toString()
@@ -63,16 +62,16 @@ export function stableSerialise(value: unknown, seen = new WeakSet<object>()): u
   if (value instanceof Date) return value.toISOString()
   if (value instanceof RegExp) return value.toString()
   if (value instanceof Error) {
-    return `[${(value as Error).constructor.name}: ${(value as Error).message}]`
+    return `[${value.constructor.name}: ${value.message}]`
   }
 
-  if (seen.has(value as object)) return '[Circular]'
-  seen.add(value as object)
+  if (seen.has(value)) return '[Circular]'
+  seen.add(value)
 
   if (value instanceof Map) {
     return {
       __type: 'Map',
-      entries: Array.from(value as Map<unknown, unknown>, ([k, v]) => [
+      entries: Array.from(value, ([k, v]) => [
         stableSerialise(k, seen),
         stableSerialise(v, seen),
       ]),
@@ -81,12 +80,12 @@ export function stableSerialise(value: unknown, seen = new WeakSet<object>()): u
   if (value instanceof Set) {
     return {
       __type: 'Set',
-      values: Array.from(value as Set<unknown>, (v) => stableSerialise(v, seen)),
+      values: Array.from(value, (v) => stableSerialise(v, seen)),
     }
   }
   if (ArrayBuffer.isView(value)) {
     return {
-      __type: (value.constructor as { name: string }).name,
+      __type: value.constructor.name,
       values: Array.from(value as unknown as ArrayLike<number>),
     }
   }
@@ -98,7 +97,7 @@ export function stableSerialise(value: unknown, seen = new WeakSet<object>()): u
   }
 
   if (Array.isArray(value)) return value.map((v) => stableSerialise(v, seen))
-  const keys = Reflect.ownKeys(value as object)
+  const keys = Reflect.ownKeys(value)
     .map((k) => k.toString())
     .sort()
   const out: Record<string, unknown> = {}
@@ -116,51 +115,62 @@ export interface SpyHost {
   readonly calls: readonly CallRecord[]
 }
 
-/** Build the `MethodSpy` facade backed by the given host. */
-export function createSpy(host: SpyHost): MethodSpy {
-  return {
-    get name() {
-      return host.name
-    },
-    get callCount() {
-      return host.calls.length
-    },
-    get calls() {
-      return host.calls
-    },
-    get firstCall() {
-      return host.calls[0]
-    },
-    get lastCall() {
-      return host.calls[host.calls.length - 1]
-    },
-    calledWith(...args: unknown[]): boolean {
-      return host.calls.some((record) =>
-        args.every((expected) => hasMatch(record.args as readonly unknown[], expected))
-      )
-    },
-    printHistory(): string {
-      if (host.calls.length === 0) return `${host.name}: (no calls)`
-      const lines = host.calls.map((c, i) => {
-        const argStr = (c.args as unknown[]).map((a) => inspect(a, { depth: 4 })).join(', ')
-        let tail = ''
-        if (c.threw !== undefined) tail = ` -> threw ${inspect(c.threw)}`
-        else if (c.returned !== undefined) tail = ` -> ${inspect(c.returned, { depth: 4 })}`
-        return `  #${i} ${host.name}(${argStr})${tail}`
-      })
-      return [`${host.name}: ${host.calls.length} call(s)`, ...lines].join('\n')
-    },
-    serialize() {
-      return {
-        method: host.name,
-        calls: host.calls.map((c) => {
-          const entry: Record<string, unknown> = { args: c.args }
-          if (c.returned !== undefined) entry.returned = c.returned
-          if (c.threw !== undefined) entry.threw = inspect(c.threw)
-          return stableSerialise(entry)
-        }),
-      }
-    },
+/**
+ * Read-only spy backed by a {@link SpyHost}.
+ * Exposes call history and inspection methods without throwing.
+ */
+export class Spy implements MethodSpy {
+  /** Create a spy backed by the given host. */
+  constructor(private readonly host: SpyHost) {}
+
+  get name(): string {
+    return this.host.name
+  }
+
+  get callCount(): number {
+    return this.host.calls.length
+  }
+
+  get calls(): readonly CallRecord[] {
+    return this.host.calls
+  }
+
+  get firstCall(): CallRecord | undefined {
+    return this.host.calls[0]
+  }
+
+  get lastCall(): CallRecord | undefined {
+    return this.host.calls[this.host.calls.length - 1]
+  }
+
+  calledWith(...args: unknown[]): boolean {
+    return this.host.calls.some((record) =>
+      args.every((expected) => hasMatch(record.args, expected))
+    )
+  }
+
+  printHistory(): string {
+    if (this.host.calls.length === 0) return `${this.host.name}: (no calls)`
+    const lines = this.host.calls.map((c, i) => {
+      const argStr = c.args.map((a) => inspect(a, { depth: 4 })).join(', ')
+      let tail = ''
+      if (c.threw !== undefined) tail = ` -> threw ${inspect(c.threw)}`
+      else if (c.returned !== undefined) tail = ` -> ${inspect(c.returned, { depth: 4 })}`
+      return `  #${i} ${this.host.name}(${argStr})${tail}`
+    })
+    return [`${this.host.name}: ${this.host.calls.length} call(s)`, ...lines].join('\n')
+  }
+
+  serialize(): { method: string; calls: unknown[] } {
+    return {
+      method: this.host.name,
+      calls: this.host.calls.map((c) => {
+        const entry: Record<string, unknown> = { args: c.args }
+        if (c.returned !== undefined) entry.returned = c.returned
+        if (c.threw !== undefined) entry.threw = inspect(c.threw)
+        return stableSerialise(entry)
+      }),
+    }
   }
 }
 
@@ -169,7 +179,7 @@ export function historySuffix(host: SpyHost): string {
   const calls = host.calls
   if (calls.length === 0) return '\n  (no calls recorded)'
   const lines = calls.map((c, i) => {
-    const argStr = (c.args as unknown[]).map((a) => inspect(a, { depth: 3 })).join(', ')
+    const argStr = c.args.map((a) => inspect(a, { depth: 3 })).join(', ')
     return `  #${i} (${argStr})`
   })
   return '\n  actual calls:\n' + lines.join('\n')

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -403,13 +403,13 @@ describe('matchers', () => {
     it('not.withArg(match.*) passes when no arg matches', () => {
       const mock = stub<Svc>(['handle'])
       mock.handle(42)
-      mock.expect.handle.called.not.withArg(match.string)
+      mock.expect.handle.not.called.withArg(match.string)
     })
 
     it('not.withArg(match.*) fails when some arg matches', () => {
       const mock = stub<Svc>(['handle'])
       mock.handle('x')
-      expect(() => mock.expect.handle.called.not.withArg(match.string)).toThrow()
+      expect(() => mock.expect.handle.not.called.withArg(match.string)).toThrow()
     })
   })
 

--- a/test/mock-expect.test.ts
+++ b/test/mock-expect.test.ts
@@ -646,6 +646,188 @@ describe('expect.called.not.* - negated expectations', () => {
   })
 })
 
+describe('expect.not.called.* - negated expectations (preferred path)', () => {
+  let bob: any
+
+  beforeEach(() => {
+    bob = deride.stub(['greet'])
+  })
+
+  it('not.never() passes when function was called', () => {
+    bob.greet('alice')
+    bob.expect.greet.not.called.never()
+  })
+
+  it('not.never() fails when function was not called', () => {
+    expect(() => bob.expect.greet.not.called.never()).toThrow()
+  })
+
+  it('not.once() fails when called exactly once', () => {
+    bob.greet('alice')
+    expect(() => bob.expect.greet.not.called.once()).toThrow()
+  })
+
+  it('not.once() passes when not called once', () => {
+    bob.greet('a')
+    bob.greet('b')
+    bob.expect.greet.not.called.once()
+  })
+
+  it('not.twice() passes when called once', () => {
+    bob.greet('alice')
+    bob.expect.greet.not.called.twice()
+  })
+
+  it('not.twice() fails when called exactly twice', () => {
+    bob.greet('a')
+    bob.greet('b')
+    expect(() => bob.expect.greet.not.called.twice()).toThrow()
+  })
+
+  it('not.times() passes when call count differs', () => {
+    bob.greet('a')
+    bob.expect.greet.not.called.times(5)
+  })
+
+  it('not.times() fails when call count matches', () => {
+    bob.greet('a')
+    expect(() => bob.expect.greet.not.called.times(1)).toThrow()
+  })
+
+  it('not.withArg() passes when arg was not used', () => {
+    bob.greet('alice')
+    bob.expect.greet.not.called.withArg('bob')
+  })
+
+  it('not.withArg() fails when arg was used', () => {
+    bob.greet('alice')
+    expect(() => bob.expect.greet.not.called.withArg('alice')).toThrow()
+  })
+
+  it('not.withArgs() passes when args were not used', () => {
+    bob.greet('alice', 'carol')
+    bob.expect.greet.not.called.withArgs('bob', 'dave')
+  })
+
+  it('not.withArgs() fails when args were used', () => {
+    bob.greet('alice', 'carol')
+    expect(() => bob.expect.greet.not.called.withArgs('alice', 'carol')).toThrow()
+  })
+
+  it('not.withMatch() passes when pattern does not match', () => {
+    bob.greet('hello world')
+    bob.expect.greet.not.called.withMatch(/^goodbye/)
+  })
+
+  it('not.withMatch() fails when pattern matches', () => {
+    bob.greet('hello world')
+    expect(() => bob.expect.greet.not.called.withMatch(/^hello/)).toThrow()
+  })
+
+  it('not.matchExactly() passes when args do not match exactly', () => {
+    bob.greet('alice', 123)
+    bob.expect.greet.not.called.matchExactly('bob', 456)
+  })
+
+  it('not.matchExactly() fails when args match exactly', () => {
+    bob.greet('alice', 123)
+    expect(() => bob.expect.greet.not.called.matchExactly('alice', 123)).toThrow()
+  })
+
+  it('not.gt() passes when call count is not greater', () => {
+    bob.greet()
+    bob.expect.greet.not.called.gt(5)
+  })
+
+  it('not.gt() fails when call count is greater', () => {
+    bob.greet()
+    bob.greet()
+    bob.greet()
+    expect(() => bob.expect.greet.not.called.gt(2)).toThrow()
+  })
+
+  it('not.lt() passes when call count is not less', () => {
+    bob.greet()
+    bob.greet()
+    bob.greet()
+    bob.expect.greet.not.called.lt(2)
+  })
+
+  it('not.lt() fails when call count is less', () => {
+    bob.greet()
+    expect(() => bob.expect.greet.not.called.lt(5)).toThrow()
+  })
+
+  it('not.gte() passes when call count is not gte', () => {
+    bob.greet()
+    bob.expect.greet.not.called.gte(5)
+  })
+
+  it('not.lte() passes when call count is not lte', () => {
+    bob.greet()
+    bob.greet()
+    bob.greet()
+    bob.expect.greet.not.called.lte(2)
+  })
+})
+
+describe('fluent chaining', () => {
+  let bob: any
+
+  beforeEach(() => {
+    bob = deride.stub(['greet'])
+    bob.setup.greet.toReturn('hi')
+  })
+
+  it('count → arg: once().withArg()', () => {
+    bob.greet('alice')
+    bob.expect.greet.called.once().withArg('alice')
+  })
+
+  it('count → arg: twice().withArgs()', () => {
+    bob.greet('a', 'b')
+    bob.greet('a', 'b')
+    bob.expect.greet.called.twice().withArgs('a', 'b')
+  })
+
+  it('count → return: once().withReturn()', () => {
+    bob.greet('alice')
+    bob.expect.greet.called.once().withReturn('hi')
+  })
+
+  it('arg → arg: withArg().withReturn()', () => {
+    bob.greet('alice')
+    bob.expect.greet.called.withArg('alice').withReturn('hi')
+  })
+
+  it('range → arg: gte().withArg()', () => {
+    bob.greet('alice')
+    bob.greet('bob')
+    bob.expect.greet.called.gte(1).withArg('alice')
+  })
+
+  it('negation with not.called chaining', () => {
+    bob.greet('alice')
+    bob.expect.greet.not.called.withArg('nobody')
+  })
+
+  it('negated count → arg chain has correct semantics', () => {
+    // Called twice with 'alice'. Negated count methods are terminal
+    // (return void) to prevent misleading De Morgan chaining.
+    // Use two separate assertions instead.
+    bob.greet('alice')
+    bob.greet('alice')
+    bob.expect.greet.not.called.once()
+    bob.expect.greet.called.withArg('alice')
+  })
+
+  it('called.not back-compat: same behaviour as not.called', () => {
+    bob.greet('alice')
+    bob.expect.greet.called.not.withArg('nobody')
+    bob.expect.greet.called.not.twice()
+  })
+})
+
 describe('expect.invocation() - specific call verification', () => {
   let bob: any
 

--- a/test/type-check.ts
+++ b/test/type-check.ts
@@ -55,3 +55,26 @@ fn.setup.toReturn('oops')
 
 // VALID: opt-out
 fn.setup.toReturn('oops' as any)
+
+// ── Expect chaining ──────────────────────────────────────────────
+
+const expectSvc = deride.stub<MyService>(['greet', 'fetchData'])
+expectSvc.setup.greet.toReturn('hi')
+expectSvc.greet('x')
+
+// VALID: count → arg chain
+expectSvc.expect.greet.called.once().withArg('x')
+
+// VALID: arg → arg chain
+expectSvc.expect.greet.called.withArg('x').withReturn('hi')
+
+// VALID: negation at MockExpect level
+expectSvc.expect.greet.not.called.withArg('nobody')
+
+// INVALID: count → count chain
+// @ts-expect-error: ArgAssertions has no 'twice'
+expectSvc.expect.greet.called.once().twice()
+
+// INVALID: never → chain (void has no properties)
+// @ts-expect-error: void has no 'withArg'
+expectSvc.expect.greet.called.never().withArg('x')

--- a/test/type-check.ts
+++ b/test/type-check.ts
@@ -78,3 +78,27 @@ expectSvc.expect.greet.called.once().twice()
 // INVALID: never → chain (void has no properties)
 // @ts-expect-error: void has no 'withArg'
 expectSvc.expect.greet.called.never().withArg('x')
+
+// ── Negated branch: count methods are terminal (issue #109 review §1) ──
+
+// VALID: negated count alone is fine
+expectSvc.expect.greet.not.called.once()
+expectSvc.expect.greet.not.called.twice()
+expectSvc.expect.greet.not.called.times(5)
+
+// INVALID: negated count → arg chain (must be type error)
+// @ts-expect-error: negated once() returns void — no chaining
+expectSvc.expect.greet.not.called.once().withArg('x')
+
+// @ts-expect-error: negated twice() returns void — no chaining
+expectSvc.expect.greet.not.called.twice().withArg('x')
+
+// @ts-expect-error: negated times() returns void — no chaining
+expectSvc.expect.greet.not.called.times(1).withArg('x')
+
+// VALID: negated arg assertions can still chain
+expectSvc.expect.greet.not.called.withArg('nobody').withReturn('nope')
+
+// VALID: deprecated called.not path still type-checks (issue #109 review §4)
+expectSvc.expect.greet.called.not.withArg('nobody')
+expectSvc.expect.greet.called.not.twice()


### PR DESCRIPTION
## Summary

Closes #107

- Extract `ArgAssertions`, `CountAssertions`, `EveryCallExpect`, and `ExpectBranches` interfaces with type-safe chaining: count methods return `ArgAssertions` (preventing count→count chains), arg methods return `ArgAssertions` (composable), `never()` and `reset()` return `void` (terminal)
- Add `expect.method.not.called.*` path for more natural negation reading. The previous `expect.method.called.not.*` path is preserved for backward compatibility
- Refactor `buildAssertions` to `AssertionBuilder` class with `Proxy`-based negation, `createSpy` to `Spy` class
- Remove unnecessary type casts across `mock-expect.ts` and `mock-spy.ts`

## Test plan

- [ ] `pnpm typecheck` passes — compile-time checks for valid/invalid chains
- [ ] `pnpm test --run` passes — 395 tests including new chaining tests and back-compat `called.not` test
- [ ] `pnpm build` succeeds
- [ ] `pnpm docs:build` succeeds
- [ ] CI matrix (Node 20/22 × ubuntu/macos/windows) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)