### PR TITLE
chore: trunk-based on main, drop develop from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop, master]
+    branches: [main]
   pull_request:
-    branches: [develop, master]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   release:
     # Skip commits semantic-release would produce itself (belt-and-braces —
-    # we no longer commit back to master, but leave the guard in place).
+    # we no longer commit back to main, but leave the guard in place).
     if: "!contains(github.event.head_commit.message, 'chore(release):')"
     runs-on: ubuntu-latest
     permissions:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["master"],
+  "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,26 +55,29 @@ echo "feat(matchers): add match.bigint" | pnpm commitlint
 
 ## Releases
 
-Releases are scoped to the `master` branch. This keeps work on `develop`
-accumulating without every merge triggering a publish.
+Trunk-based: `main` is the only long-lived branch. Every conventional-commit
+merge into `main` is potentially a release.
 
 **Branch roles:**
 
 | Branch | Role |
 |--------|------|
-| `develop` | Default integration branch. All PRs target it. |
-| `master` | Release branch. Merging `develop` → `master` cuts a release. |
-| `feature/*`, `fix/*` | Work branches, PR'd into `develop`. |
+| `main` | Trunk. Every push runs CI; every conventional-commit merge can publish a release. |
+| `feature/*`, `fix/*`, `chore/*` | Short-lived work branches, PR'd into `main`. Delete on merge. |
 
 **Cutting a release:**
 
-1. Land the relevant conventional-commit PRs on `develop`.
-2. Open a PR from `develop` → `master` (or fast-forward if preferred).
-3. Merge it. [semantic-release](https://github.com/semantic-release/semantic-release) runs automatically on `master`:
+1. Open a PR from a short-lived branch into `main` with a conventional-commit title.
+2. Squash-merge it — the squash commit message must keep the conventional prefix
+   (`feat:`, `fix:`, `perf:`, `refactor:`, `revert:`, or `docs(README):`) so
+   [semantic-release](https://github.com/semantic-release/semantic-release)
+   recognises it. Plain `chore:` / `merge:` / `ci:` titles will be skipped.
+3. semantic-release runs automatically on `main`:
    - computes the next version from the commits since the last tag,
    - creates the git tag,
-   - publishes to npm with provenance,
-   - posts a GitHub release with auto-generated notes.
+   - publishes to npm,
+   - posts a GitHub release with auto-generated notes,
+   - snapshots `docs/next` → `docs/v<major>` and deploys the docs site.
 4. Nothing to do manually.
 
 `package.json` and `CHANGELOG.md` in the repo are **not** auto-updated —

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -176,7 +176,7 @@ export default defineConfig({
     ],
 
     editLink: {
-      pattern: 'https://github.com/guzzlerio/deride/edit/develop/docs/:path',
+      pattern: 'https://github.com/guzzlerio/deride/edit/main/docs/:path',
       text: 'Edit this page on GitHub',
     },
 
@@ -188,7 +188,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Released under the <a href="https://github.com/guzzlerio/deride/blob/develop/LICENSE-MIT">MIT License</a>.',
+      message: 'Released under the <a href="https://github.com/guzzlerio/deride/blob/main/LICENSE-MIT">MIT License</a>.',
       copyright: 'Copyright © 2014-present Andrew Rea & James Allen',
     },
 

--- a/docs/next/ai/canonical-examples.md
+++ b/docs/next/ai/canonical-examples.md
@@ -254,6 +254,6 @@ For `jest`: replace `'deride/vitest'` with `'deride/jest'`. Everything else is i
 - Don't `vi.spyOn(x, 'method')` and then try to use deride — pick one.
 - Don't mutate `mock.spy.calls[i].args` and expect the mock to "react" — those are records, not controls.
 - Don't `await mock.expect.x.called.withReturn(v)` — `expect` returns void, not a Promise.
-- Don't squash-merge a deride release PR — see the [CLAUDE.md](https://github.com/guzzlerio/deride/blob/develop/CLAUDE.md) at the repo root.
+- Don't squash-merge a deride release PR — see the [CLAUDE.md](https://github.com/guzzlerio/deride/blob/main/CLAUDE.md) at the repo root.
 
 Full list of anti-patterns and their fixes: [Common mistakes](./common-mistakes).

--- a/docs/next/ai/feeds.md
+++ b/docs/next/ai/feeds.md
@@ -93,7 +93,7 @@ For embedding-based retrieval, the `.md` variants are ideal input — no HTML to
 
 ## How these feeds are maintained
 
-A VitePress `buildEnd` hook in [`docs/.vitepress/emit-llm-assets.ts`](https://github.com/guzzlerio/deride/blob/develop/docs/.vitepress/emit-llm-assets.ts) walks the source markdown, strips frontmatter, and writes:
+A VitePress `buildEnd` hook in [`docs/.vitepress/emit-llm-assets.ts`](https://github.com/guzzlerio/deride/blob/main/docs/.vitepress/emit-llm-assets.ts) walks the source markdown, strips frontmatter, and writes:
 
 - `dist/<page>.md` — a clean Markdown copy of every page
 - `dist/llms.txt` — the llmstxt.org index

--- a/docs/v2/ai/canonical-examples.md
+++ b/docs/v2/ai/canonical-examples.md
@@ -255,6 +255,6 @@ For `jest`: replace `'deride/vitest'` with `'deride/jest'`. Everything else is i
 - Don't `vi.spyOn(x, 'method')` and then try to use deride — pick one.
 - Don't mutate `mock.spy.calls[i].args` and expect the mock to "react" — those are records, not controls.
 - Don't `await mock.expect.x.called.withReturn(v)` — `expect` returns void, not a Promise.
-- Don't squash-merge a deride release PR — see the [CLAUDE.md](https://github.com/guzzlerio/deride/blob/develop/CLAUDE.md) at the repo root.
+- Don't squash-merge a deride release PR — see the [CLAUDE.md](https://github.com/guzzlerio/deride/blob/main/CLAUDE.md) at the repo root.
 
 Full list of anti-patterns and their fixes: [Common mistakes](./common-mistakes).

--- a/docs/v2/ai/feeds.md
+++ b/docs/v2/ai/feeds.md
@@ -93,7 +93,7 @@ For embedding-based retrieval, the `.md` variants are ideal input — no HTML to
 
 ## How these feeds are maintained
 
-A VitePress `buildEnd` hook in [`docs/.vitepress/emit-llm-assets.ts`](https://github.com/guzzlerio/deride/blob/develop/docs/.vitepress/emit-llm-assets.ts) walks the source markdown, strips frontmatter, and writes:
+A VitePress `buildEnd` hook in [`docs/.vitepress/emit-llm-assets.ts`](https://github.com/guzzlerio/deride/blob/main/docs/.vitepress/emit-llm-assets.ts) walks the source markdown, strips frontmatter, and writes:
 
 - `dist/<page>.md` — a clean Markdown copy of every page
 - `dist/llms.txt` — the llmstxt.org index


### PR DESCRIPTION
## Summary

Pairs with the master → main rename (already applied via API; default branch is now \`main\`).

- \`.releaserc.json\` → release branch \`main\`
- \`ci.yml\` / \`release.yml\` / \`docs.yml\` → trigger on \`main\` only
- \`vitepress\` config → edit-link + footer URLs use \`/main/\`
- \`CONTRIBUTING.md\` → rewrites the branch-model section for trunk-based dev with short-lived branches; explicitly calls out the squash-title gotcha that swallowed v2.2's release on PR #112
- \`docs/{next,v2}/ai/*\` → rewrites \`blob/develop\` references to \`blob/main\`

## After this lands

- \`develop\` is no longer wired up to anything.
- Open question for follow-up: archive (rename to \`archive/develop\`) or delete \`develop\` outright. Not done in this PR.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm docs:build\` succeeds (104 \`.md\` agent variants, llms feeds rebuilt)
- [ ] CI green on this PR
- [ ] After merge, the next conventional-commit PR into \`main\` produces a release as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)