### PR TITLE
ci(deps): bump the GitHub Pages actions in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Build VitePress
         run: pnpm docs:build
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -56,4 +56,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Supersedes #116, #117 and #119.

Combined into one PR because branch protection on `main` requires branches to be up to date and repository auto-merge is disabled — three separate PRs means three rebase-and-merge cycles for three one-line edits.

| Action | From | To |
|---|---|---|
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

## Why these are worth bumping (and a bug found while checking)

These three are the **live** docs deploy path. `GET /repos/guzzlerio/deride/pages` reports `build_type: "workflow"`, meaning the site is served from the artifact `docs.yml` uploads via `deploy-pages`.

That contradicts CLAUDE.md, which states *"Pages source must be set to 'Deploy from a branch' (`gh-pages`)"*. It isn't, and hasn't been since around 2026-04-20.

**The consequence is a separate bug:** `release.yml` deploys versioned release docs (`/latest/`, `/v{major}/`) with `peaceiris/actions-gh-pages@v4`, which pushes to the `gh-pages` branch. With `build_type: "workflow"`, Pages does not serve that branch. The last push to `gh-pages` was 2026-04-25 (`deploy: 5d0d522…`); the last actual Pages build from a branch was 2026-04-20, before the switch. So the release-time versioned docs snapshot is built in the runner and pushed somewhere nothing reads.

Out of scope for this PR — filed separately. This PR only bumps the actions on the path that does work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)