### PR TITLE
ci: prepare release workflow for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write        # creating git tags and GitHub releases
       issues: write          # semantic-release opens issues on failure
       pull-requests: write
-      id-token: write        # npm provenance
+      id-token: write        # OIDC — npm trusted publishing + provenance
     steps:
       - uses: actions/checkout@v6
         with:
@@ -31,6 +31,18 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) needs npm CLI >= 11.5.1. Node 22 bundles npm
+      # 10.9.x, which cannot perform the exchange. This matters because
+      # @semantic-release/npm treats a successful exchange as proof that auth is
+      # handled and returns *without* writing any token into .npmrc — so it then
+      # runs `npm publish` with no credentials, and an npm that can't do OIDC
+      # fails there. Installs use pnpm; publishing still goes through npm.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
       - run: pnpm install --frozen-lockfile
 
       # Re-run the gate before publishing so a red build never reaches npm,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,16 @@ If a squash is unavoidable, rename the squash commit message to `feat: …` or `
 
 **`@semantic-release/git` and `@semantic-release/changelog` are intentionally not used, and are no longer installed.** Both would try to push a `chore(release):` commit back to the release branch, which branch protection rejects. Don't re-add them to `devDependencies` — they sat there unused (and generating dependabot majors) until they were removed. `package.json` and `CHANGELOG.md` in the repo are not auto-maintained — the authoritative record is the [GitHub Releases page](https://github.com/guzzlerio/deride/releases).
 
-**Secrets required by the release workflow:** `NPM_TOKEN` (automation token with publish + provenance rights). `GITHUB_TOKEN` is provided automatically.
+**npm authentication uses trusted publishing (OIDC) — not a long-lived token.** The publisher is configured registry-side at npmjs.com → deride → Settings → Trusted Publisher, pinned to this repo and `release.yml`. The workflow grants `id-token: write`, and `@semantic-release/npm` exchanges the GitHub OIDC token for a short-lived registry credential.
+
+Two consequences worth knowing before editing `release.yml`:
+
+- **Renaming the workflow file breaks publishing.** The trusted publisher config pins the filename. Rename it and the OIDC exchange returns 404 and the release fails.
+- **npm CLI must be >= 11.5.1.** Node 22 bundles npm 10.9.x, so the workflow upgrades npm explicitly. On a successful exchange the plugin writes *no* token to `.npmrc`, so `npm publish` has to authenticate via OIDC itself — an older npm reaches that point with no credentials. Don't remove that step.
+
+Provenance is generated automatically under trusted publishing. It was never actually enabled before (nothing passed `--provenance`, and `deride@2.2.0` has no attestations) despite the workflow comment claiming otherwise.
+
+**Secrets:** `GITHUB_TOKEN` is provided automatically. `NPM_TOKEN` is retained only as a fallback — `@semantic-release/npm` uses it when the OIDC exchange fails. It is not the primary path.
 
 ## Conventional Commits — enforced on every PR
 


### PR DESCRIPTION
Part of #134. This is the **repo-side half only** — the trusted publisher must be configured at npmjs.com before it takes effect, which needs a login + 2FA and so can't be done from here. Steps below.

## Staged publishing vs trusted publishing

Worth naming the distinction, since the two get conflated:

- **Trusted publishing (OIDC)** — replaces the long-lived token with a short-lived, workflow-scoped credential. **This is what fixes #134.**
- **Staged publishing** — a review gate: `npm stage publish`, then a maintainer approves with 2FA before it goes live. It *complements* trusted publishing and explicitly does **not** remove the need for a token. It also converts semantic-release from fully automated to human-gated on every release.

So staged publishing is a reasonable thing to want, but it's a separate decision and it wouldn't fix the failing release.

## What this PR changes

One step, plus a comment explaining why it can't be removed:

```yaml
- name: Ensure npm supports trusted publishing
  run: |
    npm install -g npm@^11.5.1
    npm --version
```

Trusted publishing requires **npm CLI >= 11.5.1**. The release job runs Node 22, which bundles **npm 10.9.8** (confirmed against `nodejs.org/dist/index.json`). Without this step the publish fails *after* OIDC is configured, in a way that's hard to diagnose.

The reason is specific to how `@semantic-release/npm@13.1.5` works. `lib/verify-auth.js`:

```js
if (await oidcContextEstablished(registry, pkg, context)) {
  return;                                   // ← no token written to .npmrc
}
await setNpmrcAuth(npmrc, registry, context);
await verifyTokenAuth(registry, npmrc, context, pkgRoot);
```

The exchanged token is used only as a boolean probe — `oidcContextEstablished` returns `!!token` and discards it. `lib/publish.js` then runs `npm publish --userconfig <npmrc>` against an npmrc containing no credentials, so **the npm CLI must perform its own OIDC exchange**. An npm that can't do that arrives with nothing at all.

`id-token: write` was already granted, so no permissions change is needed.

## What you need to do at npmjs.com

npmjs.com → **deride** → Settings → Trusted Publisher → GitHub Actions:

| Field | Value |
|---|---|
| Organization or user | `guzzlerio` |
| Repository | `deride` |
| Workflow filename | `release.yml` |
| Environment | *(leave empty)* |
| Allowed actions | `npm publish` |

`deride` already exists on the registry (2.2.0 is `latest`), so the "package must already exist" precondition is met.

⚠️ The config pins the **workflow filename**. Renaming `release.yml` later breaks publishing with a 404 on the exchange. Noted in CLAUDE.md.

## Suggested rollout

Merging this PR is itself a safe live test. `semantic-release` runs `verifyConditions` *before* analysing commits, so the Release workflow exercises the OIDC exchange on every push to `main` — but this is a `ci:` commit, so nothing is releasable and nothing publishes.

1. Configure the trusted publisher (above).
2. Merge this PR. Watch the Release run for `OIDC token exchange with the npm registry succeeded`. No publish happens.
3. Only then merge #135, which publishes **v3.0.0** over the now-proven path.
4. Once that succeeds, delete the `NPM_TOKEN` secret.

`NPM_TOKEN` is deliberately **left in place** in this PR — the plugin falls back to it when the exchange fails, so it's the rollback until a real publish has gone through. It's currently invalid, so the fallback is a dead end, but removing it now would only change one failure mode for another.

Note that until step 1 is done, every push to `main` produces a red Release run. That's pre-existing (#134), not introduced here.

## Bonus: provenance

CLAUDE.md described `NPM_TOKEN` as needing "publish + provenance rights", and the workflow commented `id-token: write  # npm provenance`. Provenance was **never actually enabled** — nothing passes `--provenance`, there's no `publishConfig`, and `deride@2.2.0` has no attestations. Trusted publishing generates provenance automatically for GitHub Actions, so this finally delivers what that line claimed. CLAUDE.md corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)